### PR TITLE
Custom routes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 xpublish
 ========
 
-Publish Xarray Datasets via a Zarr compatible REST API
+Publish Xarray Datasets via a REST API.
 
 .. image:: https://img.shields.io/github/workflow/status/xarray-contrib/xpublish/CI?logo=github
    :target: https://github.com/xarray-contrib/xpublish/actions?query=workflow%3ACI
@@ -18,7 +18,7 @@ Publish Xarray Datasets via a Zarr compatible REST API
 .. image:: https://codecov.io/gh/xarray-contrib/xpublish/branch/master/graph/badge.svg
    :target: https://codecov.io/gh/xarray-contrib/xpublish
 
-**Serverside: Publish a xarray dataset as a rest API**
+**Serverside: Publish a xarray dataset through a rest API**
 
 .. code-block:: python
 
@@ -26,6 +26,9 @@ Publish Xarray Datasets via a Zarr compatible REST API
 
 
 **Client-side: Connect to a published dataset**
+
+The published dataset can be accessed from various kinds of client applications.
+Here is an example of directly accessing the data from within Python:
 
 .. code-block:: python
 
@@ -47,18 +50,24 @@ Why?
 ^^^^
 
 xpublish lets you serve/share/publish xarray datasets via a web application.
-The data in the xarray datasets (on the server side) can be backed by dask to facilitate on-demand computation via a simple REST API.
+
+The data and/or metadata in the xarray datasets can be exposed in various forms
+through pluggable REST API endpoints. Efficient, on-demand delivery of large
+datasets may be enabled with Dask on the server-side.
+
 We are exploring applications of xpublish that include:
 
-* publish on-demand derived data products
+* publish on-demand or derived data products
 * turning xarray objects into streaming services (e.g. OPENDAP)
 
 How?
 ^^^^
 
-Under the hood, xpublish is using a web app (FastAPI) that is exposing a minimal Zarr compatible REST-like API.
-Key attributes of the API are:
+Under the hood, xpublish is using a web app (FastAPI) that is exposing a
+REST-like API with builtin and/or user-defined endpoints.
 
-* serves a Zarr store API from the root of the dataset
-* provides Zarr metadata keys (\ ``.zmetadata``\ ) as json strings.
-* provides access to data keys (e.g. ``var/0.0.0``\ ) as binary strings.
+For example, xpublish provides by default a minimal Zarr compatible REST-like
+API with the following endpoints:
+
+* ``.zmetadata``: returns Zarr-formatted metadata keys as json strings.
+* ``var/0.0.0``: returns a variable data chunk as a binary string.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@
 xpublish
 ========
 
-**Xpublish lets you publish Xarray datasets via a Zarr-compatible REST API.**
+**Xpublish lets you easily publish Xarray datasets via a REST API.**
 
 *You can run a short example application in a live session here:* |Binder|
 
@@ -15,7 +15,8 @@ On the server-side, datasets are published using a simple Xarray accessor:
 
     ds.rest.serve(host="0.0.0.0", port=9000)
 
-On the client-side, datasets are accessed using Zarr and fsspec.
+Datasets can be accessed from various kinds of client applications, e.g., from
+within Python using Zarr and fsspec.
 
 .. ipython:: python
     :verbatim:
@@ -36,26 +37,29 @@ On the client-side, datasets are accessed using Zarr and fsspec.
 Why?
 ~~~~
 
-Xpublish lets you share, publish, and serve Xarray datasets via a web application.
-The data in the Xarray datasets (on the server side) can be backed by dask to
-facilitate on-demand computation via a simple REST API.
+xpublish lets you serve, share and publish xarray datasets via a web
+application.
+
+The data and/or metadata in the xarray datasets can be exposed in various forms
+through pluggable REST API endpoints. Efficient, on-demand delivery of large
+datasets may be enabled with Dask on the server-side.
 
 We are exploring applications of xpublish that include:
 
-- publish on-demand or derived data products
-- turning Xarray objects into streaming services (e.g. OPENDAP)
+* publish on-demand or derived data products
+* turning xarray objects into streaming services (e.g. OPENDAP)
 
 How?
 ~~~~
 
 Under the hood, xpublish is using a web app (FastAPI and Uvicorn) that is
-exposing a minimal Zarr compatible REST-like API.
+exposing a REST-like API with builtin and/or user-defined endpoints.
 
-Key attributes of the API are:
+For example, xpublish provides by default a minimal Zarr compatible REST-like
+API with the following endpoints:
 
-- serves a Zarr store API from the root of the dataset.
-- provides Zarr metadata keys (``.zmetadata``, ``.zgroup``, ``.zarray``, and ``.zattrs``) as a JSON strings.
-- provides access to data keys (e.g. ``var/0.0.0``) as binary strings.
+* ``.zmetadata``: returns Zarr-formatted metadata keys as json strings.
+* ``var/0.0.0``: returns a variable data chunk as a binary string.
 
 .. toctree::
    :maxdepth: 2
@@ -70,7 +74,7 @@ Feedback
 --------
 
 If you encounter any errors or problems with **xpublish**, please open an issue
-at the GitHub `main repository <http://github.com/jhamman/xpublish>`_.
+at the GitHub `main repository <http://github.com/xarray-contrib/xpublish>`_.
 
 Indices and tables
 ==================

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -90,9 +90,9 @@ Using those settings, Zarr API endpoints now have the following paths:
 * ``/data/.zmetadata``
 * ``/data/{var}/{key}``
 
-It is also possible to create custom API routes and serve them via the
-application. In the example below, we create a very minimal application to get
-the mean value of a given variable in the published dataset:
+It is also possible to create custom API routes and serve them via Xpublish. In
+the example below, we create a very minimal application to get the mean value of
+a given variable in the published dataset:
 
 .. code-block:: python
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -65,13 +65,7 @@ def test_init_app(airtemp_ds):
     assert response.status_code == 200
 
 
-@pytest.mark.parametrize(
-    'router_kws,path',
-    [
-        (None, '/dims'),
-        ({'prefix': '/foo'}, '/foo/dims'),
-    ]
-)
+@pytest.mark.parametrize('router_kws,path', [(None, '/dims'), ({'prefix': '/foo'}, '/foo/dims'),])
 def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
     if router_kws is None:
         routers = [dims_router]

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -65,7 +65,7 @@ def test_init_app(airtemp_ds):
     assert response.status_code == 200
 
 
-@pytest.mark.parametrize('router_kws,path', [(None, '/dims'), ({'prefix': '/foo'}, '/foo/dims'),])
+@pytest.mark.parametrize('router_kws,path', [(None, '/dims'), ({'prefix': '/foo'}, '/foo/dims')])
 def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
     if router_kws is None:
         routers = [dims_router]
@@ -87,6 +87,23 @@ def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
 def test_custom_app_routers_error(airtemp_ds):
     with pytest.raises(ValueError, match="Invalid format.*"):
         airtemp_ds.rest(routers=["not_a_router"])
+
+
+def test_custom_app_routers_conflict(airtemp_ds):
+    router1 = APIRouter()
+
+    @router1.get('/path')
+    def func1():
+        pass
+
+    router2 = APIRouter()
+
+    @router2.get('/same/path')
+    def func2():
+        pass
+
+    with pytest.raises(ValueError, match="Found multiple routes.*"):
+        airtemp_ds.rest(routers=[(router1, {'prefix': '/same'}), router2])
 
 
 def test_keys(airtemp_ds, airtemp_app):

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 from .dependencies import get_cache, get_dataset
 from .routers import base_router, common_router, zarr_router
-from .utils.api import normalize_app_routers
+from .utils.api import check_route_conflicts, normalize_app_routers
 
 
 @xr.register_dataset_accessor('rest')
@@ -68,6 +68,7 @@ class RestAccessor:
 
         if routers is not None:
             self._app_routers = normalize_app_routers(routers)
+            check_route_conflicts(self._app_routers)
         if app_kws is not None:
             self._app_kws.update(app_kws)
         if cache_kws is not None:

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 
 from .dependencies import get_cache, get_dataset
 from .routers import base_router, common_router, zarr_router
+from .utils.api import normalize_app_routers
 
 
 @xr.register_dataset_accessor('rest')
@@ -28,22 +29,32 @@ class RestAccessor:
 
         self._app = None
         self._app_kws = {}
-        self._app_routers = [common_router, base_router, zarr_router]
+        self._app_routers = [
+            (common_router, {}),
+            (base_router, {'tags': ['info']}),
+            (zarr_router, {'tags': ['zarr']}),
+        ]
 
         self._cache = None
         self._cache_kws = {'available_bytes': 1e6}
 
         self._initialized = False
 
-    def __call__(self, cache_kws=None, app_kws=None):
+    def __call__(self, routers=None, cache_kws=None, app_kws=None):
         """
         Initialize this RestAccessor by setting optional configuration values
 
         Parameters
         ----------
-        cache_kws : dict
+        routers : list, optional
+            A list of :class:`fastapi.APIRouter` instances to include in the
+            fastAPI application. If None, the default routers will be included.
+            The items of the list may also be tuples with the following format:
+            ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``.
+            This is useful for passing arguments to :meth:`fastapi.FastAPI.include_router`.
+        cache_kws : dict, optional
             Dictionary of keyword arguments to be passed to ``cachey.Cache()``
-        app_kws : dict
+        app_kws : dict, optional
             Dictionary of keyword arguments to be passed to
             ``fastapi.FastAPI()``
 
@@ -55,6 +66,8 @@ class RestAccessor:
             raise RuntimeError('This accessor has already been initialized')
         self._initialized = True
 
+        if routers is not None:
+            self._app_routers = normalize_app_routers(routers)
         if app_kws is not None:
             self._app_kws.update(app_kws)
         if cache_kws is not None:
@@ -75,8 +88,8 @@ class RestAccessor:
 
         self._app = FastAPI(**self._app_kws)
 
-        for r in self._app_routers:
-            self._app.include_router(r, prefix='')
+        for rt, kwargs in self._app_routers:
+            self._app.include_router(rt, **kwargs)
 
         self._app.dependency_overrides[get_dataset] = lambda: self._obj
         self._app.dependency_overrides[get_cache] = lambda: self.cache

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -51,7 +51,9 @@ class RestAccessor:
             fastAPI application. If None, the default routers will be included.
             The items of the list may also be tuples with the following format:
             ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``.
-            This is useful for passing arguments to :meth:`fastapi.FastAPI.include_router`.
+            The 1st tuple element is a ``APIRouter`` instance and the 2nd element
+            is a dictionary that is used to pass keyword arguments to
+            :meth:`fastapi.FastAPI.include_router`.
         cache_kws : dict, optional
             Dictionary of keyword arguments to be passed to ``cachey.Cache()``
         app_kws : dict, optional

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -17,3 +17,24 @@ def normalize_app_routers(routers):
             )
 
     return new_routers
+
+
+def check_route_conflicts(routers):
+
+    paths = []
+
+    for router, kws in routers:
+        prefix = kws.get('prefix', '')
+        paths += [prefix + r.path for r in router.routes]
+
+    seen = set()
+    duplicates = []
+
+    for p in paths:
+        if p in seen:
+            duplicates.append(p)
+        else:
+            seen.add(p)
+
+    if len(duplicates):
+        raise ValueError(f"Found multiple routes defined for the following paths: {duplicates}")

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -7,7 +7,7 @@ def normalize_app_routers(routers):
 
     for rt in routers:
         if isinstance(rt, APIRouter):
-            new_routers.append(rt, {})
+            new_routers.append((rt, {}))
         elif isinstance(rt, tuple) and isinstance(rt[0], APIRouter) and len(rt) == 2:
             new_routers.append(rt)
         else:

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+
+
+def normalize_app_routers(routers):
+
+    new_routers = []
+
+    for rt in routers:
+        if isinstance(rt, APIRouter):
+            new_routers.append(rt, {})
+        elif isinstance(rt, tuple) and isinstance(rt[0], APIRouter) and len(rt) == 2:
+            new_routers.append(rt)
+        else:
+            raise ValueError(
+                "Invalid format for routers item, please provide either an APIRouter "
+                "instance or a (APIRouter, {...}) tuple."
+            )
+
+    return new_routers


### PR DESCRIPTION
Follow-up #27.

Custom API routers may be plugged in the FastAPI application using the new `routers` argument when calling the `rest` accessor. This completely overrides the default routers, although it is still possible to reuse the latter ones by importing them from `xpublish.routers` and including them in the given list of routers.

TODO:

- [x] explicitly check for API path conflicts
- [x] more doc updates.