### PR TITLE
Doc fixes, tweaks and improvements

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,7 +13,6 @@ sphinx:
 python:
   version: 3.7
   install:
-    - requirements: requirements.txt
     - requirements: docs/requirements.txt
     - method: pip
       path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 numpydoc
+sphinx
 sphinx_copybutton
-ipykernel
-netCDF4
 git+https://github.com/keewis/sphinx-autosummary-accessors

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-numpydoc
 sphinx
 sphinx_copybutton
 git+https://github.com/keewis/sphinx-autosummary-accessors

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ numpydoc
 sphinx_copybutton
 ipykernel
 netCDF4
+git+https://github.com/keewis/sphinx-autosummary-accessors

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -44,3 +44,19 @@ properties listed below. Proper use of this accessor should be like:
    :template: autosummary/accessor_method.rst
 
    Dataset.rest.serve
+
+FastAPI dependencies
+====================
+
+The functions below are defined in module ``xpublish.dependencies`` and can
+be used as FastAPI dependencies when creating custom API endpoints.
+
+.. currentmodule:: xpublish.dependencies
+
+.. autosummary::
+   :toctree: generated/
+
+   get_dataset
+   get_cache
+   get_zvariables
+   get_zmetadata

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -13,9 +13,9 @@ properties listed below. Proper use of this accessor should be like:
 .. code-block:: python
 
    >>> import xarray as xr         # first import xarray
-   >>> import xpublish             # import xpublish (the 'rest' accessor is registered for datasets)
+   >>> import xpublish             # import xpublish (the dataset 'rest' accessor is registered)
    >>> ds = xr.Dataset()           # create or load an xarray Dataset
-   >>> ds.rest(...)                # call the 'rest' accessor
+   >>> ds.rest(...)                # call the 'rest' accessor on the dataset
    >>> ds.rest.<meth_or_prop>      # access to the methods and properties listed below
 
 .. currentmodule:: xarray

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,12 +4,43 @@
 API reference
 #############
 
-This is a reference API class listing, and modules.
+Dataset.rest (xarray accessor)
+==============================
 
-Accessor Objects
-================
+This accessor extends :py:class:`xarray.Dataset` with all the methods and
+properties listed below. Proper use of this accessor should be like:
+
+.. code-block:: python
+
+   >>> import xarray as xr         # first import xarray
+   >>> import xpublish             # import xpublish (the 'rest' accessor is registered for datasets)
+   >>> ds = xr.Dataset()           # create or load an xarray Dataset
+   >>> ds.rest(...)                # call the 'rest' accessor
+   >>> ds.rest.<meth_or_prop>      # access to the methods and properties listed below
+
+.. currentmodule:: xarray
+
+**Calling the accessor**
 
 .. autosummary::
    :toctree: generated/
+   :template: autosummary/accessor_callable.rst
 
-   RestAccessor
+   Dataset.rest
+
+**Properties**
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/accessor_attribute.rst
+
+   Dataset.rest.app
+   Dataset.rest.cache
+
+**Methods**
+
+.. autosummary::
+   :toctree: generated/
+   :template: autosummary/accessor_method.rst
+
+   Dataset.rest.serve

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,8 @@
 import os
 import sys
 
+import sphinx_autosummary_accessors
+
 import xpublish
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -41,6 +43,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
     'numpydoc',
+    'sphinx_autosummary_accessors',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
 ]
@@ -50,7 +53,7 @@ extlinks = {
     'pr': ('https://github.com/xarray-contrib/xpublish/pull/%s', 'GH#'),
 }
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ['_templates', sphinx_autosummary_accessors.templates_path]
 
 # Generate the API documentation when building
 autosummary_generate = True
@@ -117,6 +120,14 @@ pygments_style = 'sphinx'
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+
+# -- Intersphinx links ---------------------------------------------------------
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3.6/', None),
+    'xarray': ('https://xarray.pydata.org/en/stable/', None),
+    # sadly, there is no intersphinx for fastapi docs
+}
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -42,7 +42,7 @@ extensions = [
     'sphinx.ext.doctest',
     'sphinx.ext.intersphinx',
     'sphinx.ext.extlinks',
-    'numpydoc',
+    'sphinx.ext.napoleon',
     'sphinx_autosummary_accessors',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
@@ -57,8 +57,6 @@ templates_path = ['_templates', sphinx_autosummary_accessors.templates_path]
 
 # Generate the API documentation when building
 autosummary_generate = True
-numpydoc_show_class_members = False
-
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,8 +44,6 @@ extensions = [
     'sphinx.ext.extlinks',
     'sphinx.ext.napoleon',
     'sphinx_autosummary_accessors',
-    'IPython.sphinxext.ipython_console_highlighting',
-    'IPython.sphinxext.ipython_directive',
 ]
 
 extlinks = {

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -8,20 +8,18 @@ so do not hesitate!
 .. contents:: Contribution links
    :depth: 2
 
-
 .. _submitfeedback:
 
 Feature requests and feedback
 -----------------------------
 
-Do you like xpublish?  Share some love on Twitter or in your blog posts!
+Do you like xpublish? Share some love on Twitter or in your blog posts!
 
 We'd also like to hear about your propositions and suggestions.  Feel free to
 `submit them as issues <https://github.com/xarray-contrib/xpublish>`_ and:
 
 * Explain in detail how they should work.
 * Keep the scope as narrow as possible.  This will make it easier to implement.
-
 
 .. _reportbugs:
 
@@ -42,7 +40,6 @@ If you can write a demonstration test that currently fails but should pass
 (xfail), that is a very useful commit to make as well, even if you cannot
 fix the bug itself.
 
-
 .. _fixbugs:
 
 Fix bugs
@@ -52,38 +49,37 @@ Look through the `GitHub issues for bugs <https://github.com/xarray-contrib/xpub
 
 Talk to developers to find out how you can fix specific bugs.
 
-
 Write documentation
 -------------------
 
-xpublish could always use more documentation.  What exactly is needed?
+xpublish could always use more documentation. What exactly is needed?
 
 * More complementary documentation.  Have you perhaps found something unclear?
 * Docstrings.  There can never be too many of them.
 * Blog posts, articles and such -- they're all very appreciated.
 
 You can also edit documentation files directly in the GitHub web interface,
-without using a local copy.  This can be convenient for small fixes.
+without using a local copy. This can be convenient for small fixes.
 
-.. note::
-    Build the documentation locally with the following command:
+To build the documentation locally, you first need to install the following
+tools:
 
-    .. code:: bash
+- `Sphinx <https://github.com/sphinx-doc/sphinx>`__
+- `sphinx_rtd_theme <https://github.com/readthedocs/sphinx_rtd_theme>`__
+- `sphinx-autosummary-accessors <https://github.com/keewis/sphinx-autosummary-accessors>`__
 
-        $ conda env update -f ci/environment-dev-3.7.yml
-        $ cd docs
-        $ make html
+You can then build the documentation with the following commands::
 
-    The built documentation should be available in the ``docs/_build/``.
+    $ cd docs
+    $ make html
 
+The built documentation should be available in the ``docs/_build/`` folder.
 
-
- .. _`pull requests`:
+.. _`pull requests`:
 .. _pull-requests:
 
 Preparing Pull Requests
 -----------------------
-
 
 #. Fork the
    `xpublish GitHub repository <https://github.com/xarray-contrib/xpublish>`__.  It's
@@ -99,7 +95,6 @@ Preparing Pull Requests
 
     $ git checkout -b your-bugfix-feature-branch-name master
 
-
 #. Install `pre-commit <https://pre-commit.com>`_ and its hook on the xpublish repo::
 
      $ pip install --user pre-commit
@@ -109,10 +104,10 @@ Preparing Pull Requests
 
    https://pre-commit.com/ is a framework for managing and maintaining multi-language pre-commit hooks
    to ensure code-style and code formatting is consistent.
+
 #. Install dependencies into a new conda environment::
 
     $ conda env update -f ci/environment-dev-3.7.yml
-
 
 #. Run all the tests
 
@@ -133,11 +128,10 @@ Preparing Pull Requests
     $ git commit -a -m "<commit message>"
     $ git push -u
 
-
 #. Finally, submit a pull request through the GitHub website using this data::
 
     head-fork: YOUR_GITHUB_USERNAME/xpublish
     compare: your-branch-name
 
-    base-fork: jhamman/xpublish
+    base-fork: xarray-contrib/xpublish
     base: master

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,8 +18,7 @@ On the server-side, datasets are published using a simple Xarray accessor:
 Datasets can be accessed from various kinds of client applications, e.g., from
 within Python using Zarr and fsspec.
 
-.. ipython:: python
-    :verbatim:
+.. code-block:: python
 
     import xarray as xr
     import zarr

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,8 +57,8 @@ exposing a REST-like API with builtin and/or user-defined endpoints.
 For example, xpublish provides by default a minimal Zarr compatible REST-like
 API with the following endpoints:
 
-* ``.zmetadata``: returns Zarr-formatted metadata keys as json strings.
-* ``var/0.0.0``: returns a variable data chunk as a binary string.
+* ``/.zmetadata``: returns Zarr-formatted metadata keys as json strings.
+* ``/var/0.0.0``: returns a variable data chunk as a binary string.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -9,6 +9,6 @@ If you are using `Anaconda`_ or Miniconda, install xpublish with the following c
 
 If you are using virtualenv/pip, run the following command::
 
-    pip install xpublish
+    python -m pip install xpublish
 
 .. _Anaconda: https://www.anaconda.com/download/

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -34,14 +34,15 @@ is initialized:
         cache_kws=dict(available_bytes=1e9)
     )
 
-Serving a dataset simply requires calling the `serve` method on the `rest`
-accessor:
+Serving a dataset simply requires calling the :meth:`~xarray.Dataset.rest.serve`
+method on the ``rest`` accessor:
 
 .. code-block:: python
 
     ds.rest.serve()
 
-`serve()` passes any keyword arguments on to `uvicorn.run`.
+:meth:`~xarray.Dataset.rest.serve` passes any keyword arguments on to
+:func:`uvicorn.run`.
 
 Default API routes
 ~~~~~~~~~~~~~~~~~~
@@ -50,10 +51,10 @@ By default, the served application provides the following endpoints to get some
 information about the published dataset:
 
 * ``/``: returns xarray's HTML repr.
-* ``/keys``: returns a list of variable keys, equivalent to ``list(ds.variables)``.
-* ``/info``: returns a JSON dictionary summary of a Dataset variables and attributes, similar to ``ds.info()``.
+* ``/keys``: returns a list of variable keys, i.e., those returned by :attr:`xarray.Dataset.variables`.
+* ``/info``: returns a JSON dictionary summary of a Dataset variables and attributes, similar to :meth:`xarray.Dataset.info`.
 * ``/dict``: returns a JSON dictionary of the full dataset.
-* ``/versions``: returns JSON dictionary of the versions of python, xarray and related libraries on the server side, similar to ``xr.show_versions()``.
+* ``/versions``: returns JSON dictionary of the versions of python, xarray and related libraries on the server side, similar to :func:`xarray.show_versions`.
 
 The application also provides data access through a Zarr compatible API with the
 following endpoints:
@@ -64,11 +65,11 @@ following endpoints:
 Custom API routes
 ~~~~~~~~~~~~~~~~~
 
-With Xpublish you have full control on which/how API endpoints are exposed by
-the application.
+With Xpublish you have full control on which and how API endpoints are exposed
+by the application.
 
 In the example below, the default API routes are included with additional tags
-and using a path prefix for zarr-like data access:
+and using a path prefix for Zarr-like data access:
 
 .. code-block:: python
 
@@ -90,43 +91,46 @@ Using those settings, Zarr API endpoints now have the following paths:
 * ``/data/{var}/{key}``
 
 It is also possible to create custom API routes and serve them via Xpublish. In
-the example below, we create a very minimal application to get the mean value of
-a given variable in the published dataset:
+the example below, we create a minimal application to get the mean value of a
+given variable in the published dataset:
 
 .. code-block:: python
 
    from fastapi import APIRouter, Depends, HTTPException
    from xpublish.dependencies import get_dataset
 
+
    myrouter = APIRouter()
 
-   @myrouter.get("{var_name}/mean")
-   def get_mean(dataset: xr.Dataset = Depends(get_dataset), var_name: str):
+
+   @myrouter.get("/{var_name}/mean")
+   def get_mean(var_name: str, dataset: xr.Dataset = Depends(get_dataset)):
        if var_name not in dataset.variables:
            raise HTTPException(
-               status_code=404, detail=f"Variable {var_name} not found in dataset"
+               status_code=404, detail=f"Variable '{var_name}' not found in dataset"
            )
 
-       return dataset[var_name].mean().item()
+       return float(dataset[var_name].mean())
+
 
    ds.rest(routers=[myrouter])
 
    ds.rest.serve()
 
-Taking the dataset loaded above in this tutorial, this minimal application
-should like this:
+Taking the dataset loaded above in this tutorial, this application should behave
+like this:
 
 * ``/air/mean`` returns a floating number
 * ``/not_a_variable/mean`` returns a 404 HTTP error
 
 The :func:`~xpublish.dependencies.get_dataset` function in the example above is
 a FastAPI dependency that is used to access the dataset object being served by
-the application from inside a FastAPI path operation decorated function or
-another FastAPI dependency. Note that ``get_dataset`` can only be used as
+the application, either from inside a FastAPI path operation decorated function
+or another FastAPI dependency. Note that ``get_dataset`` can only be used as
 function arguments.
 
 Xpublish also provides a :func:`~xpublish.dependencies.get_cache` dependency
-function to get/put any useful key/value pair from/into the cache that is
+function to get/put any useful key-value pair from/into the cache that is
 created along with a running instance of the application.
 
 API Docs
@@ -143,8 +147,8 @@ dictionary argument when initializing the rest accessor.
 Client-Side
 -----------
 
-Datasets served by xpublish are can be opened by any zarr client that
-implements an HTTPStore. In Python, this can be done with fsspec:
+Datasets served by xpublish are can be opened by any Zarr client that
+implements an HTTPStore. In Python, this can be done with ``fsspec``:
 
 .. code-block:: python
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -9,7 +9,7 @@ Xpublish provides a simple accessor interface to serve xarray objects.
 
 To begin, import xpublish and open an xarray dataset:
 
-.. ipython:: python
+.. code-block:: python
 
     import xarray as xr
     import xpublish
@@ -23,7 +23,7 @@ Optional customization of the underlying
 `cache <https://github.com/dask/cachey>`_ is possible when the accessor
 is initialized:
 
-.. ipython:: python
+.. code-block:: python
 
     ds.rest(
         app_kws=dict(
@@ -37,8 +37,7 @@ is initialized:
 Serving a dataset simply requires calling the `serve` method on the `rest`
 accessor:
 
-.. ipython:: python
-    :verbatim:
+.. code-block:: python
 
     ds.rest.serve()
 
@@ -146,8 +145,7 @@ Client-Side
 Datasets served by xpublish are can be opened by any zarr client that
 implements an HTTPStore. In Python, this can be done with fsspec:
 
-.. ipython:: python
-    :verbatim:
+.. code-block:: python
 
     import zarr
     from fsspec.implementations.http import HTTPFileSystem
@@ -163,8 +161,7 @@ implements an HTTPStore. In Python, this can be done with fsspec:
 
 Xpublish's endpoints can also be queried programmatically. For example:
 
-.. ipython:: python
-    :verbatim:
+.. code-block:: python
 
     import requests
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -119,14 +119,15 @@ should like this:
 * ``/air/mean`` returns a floating number
 * ``/not_a_variable/mean`` returns a 404 HTTP error
 
-The ``get_dataset`` function in the example above is a FastAPI dependency that
-is used to access the dataset object being served by the application from inside
-a FastAPI path operation decorated function or another FastAPI dependency. Note
-that ``get_dataset`` can only be used as function arguments.
+The :func:`~xpublish.dependencies.get_dataset` function in the example above is
+a FastAPI dependency that is used to access the dataset object being served by
+the application from inside a FastAPI path operation decorated function or
+another FastAPI dependency. Note that ``get_dataset`` can only be used as
+function arguments.
 
-Xpublish also provides a ``get_cache`` dependency function to get/put any useful
-key/value pair from/into the cache that is created along with a running instance
-of the application.
+Xpublish also provides a :func:`~xpublish.dependencies.get_cache` dependency
+function to get/put any useful key/value pair from/into the cache that is
+created along with a running instance of the application.
 
 API Docs
 ~~~~~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=xpublish
-known_third_party=cachey,dask,fastapi,numcodecs,numpy,pandas,pkg_resources,pytest,setuptools,starlette,uvicorn,xarray,zarr
+known_third_party=cachey,dask,fastapi,numcodecs,numpy,pandas,pkg_resources,pytest,setuptools,sphinx_autosummary_accessors,starlette,uvicorn,xarray,zarr
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -9,7 +9,7 @@ from .utils.zarr import create_zmetadata, create_zvariables, zarr_metadata_key
 
 
 def get_dataset():
-    """FastAPI dependency for accessing a xarray dataset object.
+    """FastAPI dependency for accessing the published xarray dataset object.
 
     Use this callable as dependency in any FastAPI path operation
     function where you need access to the xarray Dataset being served.

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -10,7 +10,7 @@ from .utils.api import check_route_conflicts, normalize_app_routers
 
 @xr.register_dataset_accessor('rest')
 class RestAccessor:
-    """ REST API Accessor
+    """REST API Accessor
 
     Parameters
     ----------
@@ -21,6 +21,7 @@ class RestAccessor:
     -----
     When using this as an accessor on an Xarray.Dataset, options are set via
     the ``RestAccessor.__call__()`` method.
+
     """
 
     def __init__(self, xarray_obj):
@@ -41,8 +42,7 @@ class RestAccessor:
         self._initialized = False
 
     def __call__(self, routers=None, cache_kws=None, app_kws=None):
-        """
-        Initialize this RestAccessor by setting optional configuration values
+        """Initialize this accessor by setting optional configuration values.
 
         Parameters
         ----------
@@ -51,18 +51,20 @@ class RestAccessor:
             fastAPI application. If None, the default routers will be included.
             The items of the list may also be tuples with the following format:
             ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``.
-            The 1st tuple element is a ``APIRouter`` instance and the 2nd element
-            is a dictionary that is used to pass keyword arguments to
+            The 1st tuple element is a :class:`fastapi.APIRouter` instance and the
+            2nd element is a dictionary that is used to pass keyword arguments to
             :meth:`fastapi.FastAPI.include_router`.
         cache_kws : dict, optional
-            Dictionary of keyword arguments to be passed to ``cachey.Cache()``
+            Dictionary of keyword arguments to be passed to
+            :meth:`cachey.Cache.__init__()`.
         app_kws : dict, optional
             Dictionary of keyword arguments to be passed to
-            ``fastapi.FastAPI()``
+            :meth:`fastapi.FastAPI.__init__()`.
 
         Notes
         -----
         This method can only be invoked once.
+
         """
         if self._initialized:
             raise RuntimeError('This accessor has already been initialized')
@@ -79,15 +81,15 @@ class RestAccessor:
         return self
 
     @property
-    def cache(self):
-        """ Cache Property """
+    def cache(self) -> cachey.Cache:
+        """Returns the :class:`cachey.Cache` instance used by the FastAPI application."""
 
         if self._cache is None:
             self._cache = cachey.Cache(**self._cache_kws)
         return self._cache
 
     def _init_app(self):
-        """ Initiate FastAPI Application. """
+        """Initiate the FastAPI application."""
 
         self._app = FastAPI(**self._app_kws)
 
@@ -100,14 +102,14 @@ class RestAccessor:
         return self._app
 
     @property
-    def app(self):
-        """ FastAPI app """
+    def app(self) -> FastAPI:
+        """Returns the :class:`fastapi.FastAPI` application instance."""
         if self._app is None:
             self._app = self._init_app()
         return self._app
 
     def serve(self, host='0.0.0.0', port=9000, log_level='debug', **kwargs):
-        """ Serve this app via ``uvicorn.run``.
+        """Serve this FastAPI application via :func:`uvicorn.run`.
 
         Parameters
         ----------
@@ -119,10 +121,11 @@ class RestAccessor:
             App logging level, valid options are
             {'critical', 'error', 'warning', 'info', 'debug', 'trace'}.
         kwargs :
-            Additional arguments to be passed to ``uvicorn.run``.
+            Additional arguments to be passed to :func:`uvicorn.run`.
 
         Notes
         -----
         This method is blocking and does not return.
+
         """
         uvicorn.run(self.app, host=host, port=port, log_level=log_level, **kwargs)


### PR DESCRIPTION
A couple of comments:

- The `rest` accessor API is now documented using [sphinx-autosummary-accessors](https://github.com/keewis/sphinx-autosummary-accessors).

- I replaced the ipython directives by regular python code blocks. I don't think using ipython directives are worth relying on ipython + all xpublish's runtime dependencies for building the docs, given that we don't really leverage the interactive output here. I'm not against reverting this change in case anyone has objections.

 
 