### PR TITLE
Publish a collection of datasets

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,8 +7,8 @@ API reference
 Top-level Rest class
 ====================
 
-The :class:`~xpublish.Rest` class can be used for publishing a collection of
-:class:`xarray.Dataset` objects.
+The :class:`~xpublish.Rest` class can be used for publishing a
+:class:`xarray.Dataset` object or a collection of Dataset objects.
 
 .. autosummary::
    :toctree: generated/
@@ -22,7 +22,7 @@ Dataset.rest (xarray accessor)
 ==============================
 
 This accessor extends :py:class:`xarray.Dataset` with the same interface than
-:class:`~xpublish.Rest`. It is the preferred method for publishing one single
+:class:`~xpublish.Rest`. It is a convenient method for publishing one single
 dataset. Proper use of this accessor should be like:
 
 .. code-block:: python

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,11 +4,26 @@
 API reference
 #############
 
+Top-level Rest class
+====================
+
+The :class:`~xpublish.Rest` class can be used for publishing a collection of
+:class:`xarray.Dataset` objects.
+
+.. autosummary::
+   :toctree: generated/
+
+   Rest
+   Rest.app
+   Rest.cache
+   Rest.serve
+
 Dataset.rest (xarray accessor)
 ==============================
 
-This accessor extends :py:class:`xarray.Dataset` with all the methods and
-properties listed below. Proper use of this accessor should be like:
+This accessor extends :py:class:`xarray.Dataset` with the same interface than
+:class:`~xpublish.Rest`. It is the preferred method for publishing one single
+dataset. Proper use of this accessor should be like:
 
 .. code-block:: python
 
@@ -56,6 +71,7 @@ be used as FastAPI dependencies when creating custom API endpoints.
 .. autosummary::
    :toctree: generated/
 
+   get_dataset_ids
    get_dataset
    get_cache
    get_zvariables

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,14 +9,15 @@ xpublish
 .. |Binder| image:: https://mybinder.org/badge_logo.svg
  :target: https://mybinder.org/v2/gh/xarray-contrib/xpublish/master
 
-On the server-side, datasets are published using a simple Xarray accessor:
+On the server-side, one or more datasets can be published using the
+:class:`xpublish.Rest` class or the :attr:`xarray.Dataset.rest` accessor, e.g.,
 
 .. code-block:: python
 
     ds.rest.serve(host="0.0.0.0", port=9000)
 
-Datasets can be accessed from various kinds of client applications, e.g., from
-within Python using Zarr and fsspec.
+Those datasets can be accessed from various kinds of client applications, e.g.,
+from within Python using Zarr and fsspec.
 
 .. code-block:: python
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -45,8 +45,9 @@ application <https://fastapi.tiangolo.com>`_ or the server-side `cache
         cache_kws=dict(available_bytes=1e9)
     )
 
-Serving the dataset then simply requires calling the :meth:`~Rest.serve` method
-on the ``Rest`` instance or the ``rest`` accessor:
+Serving the dataset then simply requires calling the
+:meth:`~xpublish.Rest.serve` method on the ``Rest`` instance or the ``rest``
+accessor:
 
 .. code-block:: python
 
@@ -56,7 +57,7 @@ on the ``Rest`` instance or the ``rest`` accessor:
 
     ds.rest.serve()
 
-:meth:`~xarray.Dataset.rest.serve` passes any keyword arguments on to
+:meth:`~xpublish.Rest.serve` passes any keyword arguments on to
 :func:`uvicorn.run`.
 
 Default API routes
@@ -142,7 +143,8 @@ The :func:`~xpublish.dependencies.get_dataset` function in the example above is
 a FastAPI dependency that is used to access the dataset object being served by
 the application, either from inside a FastAPI path operation decorated function
 or from another FastAPI dependency. Note that ``get_dataset`` can only be used
-as function arguments.
+as a function argument (FastAPI has other ways to reuse a dependency, but those
+are not supported in this case).
 
 Xpublish also provides a :func:`~xpublish.dependencies.get_cache` dependency
 function to get/put any useful key-value pair from/into the cache that is
@@ -180,12 +182,12 @@ the ``/datasets/{dataset_id}`` prefix. For example:
 * ``/datasets/rasm/info`` returns information about the ``rasm`` dataset
 * ``/datasets/invalid_dataset_id/info`` returns a 404 HTTP error
 
-The application has also one more API endpoint:
+The application also has one more API endpoint:
 
 * ``/datasets``: returns the list of the ids (keys) of all published datasets
 
 Note that custom routes work for multiple datasets just as well as for a single
-dataset, no code change is required. Taking the example above,
+dataset. No code change is required. Taking the example above,
 
 .. code-block:: python
 
@@ -204,7 +206,7 @@ The following URLs should return expected results:
 Client-Side
 -----------
 
-By default, datasets served by Xpublish are can be opened by any Zarr client
+By default, datasets served by Xpublish can be opened by any Zarr client
 that implements an HTTPStore. In Python, this can be done with ``fsspec``:
 
 .. code-block:: python

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -46,8 +46,8 @@ application <https://fastapi.tiangolo.com>`_ or the server-side `cache
     )
 
 Serving the dataset then simply requires calling the
-:meth:`~xpublish.Rest.serve` method on the ``Rest`` instance or the ``rest``
-accessor:
+:meth:`~xpublish.Rest.serve` method on the :class:`~xpublish.Rest` instance or
+the :attr:`xarray.Dataset.rest` accessor:
 
 .. code-block:: python
 
@@ -58,7 +58,9 @@ accessor:
     ds.rest.serve()
 
 :meth:`~xpublish.Rest.serve` passes any keyword arguments on to
-:func:`uvicorn.run`.
+:func:`uvicorn.run` (see `Uvicorn docs`_).
+
+.. _`Uvicorn docs`: https://www.uvicorn.org/deployment/#running-programmatically
 
 Default API routes
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -5,9 +5,7 @@ Tutorial
 Server-Side
 -----------
 
-Xpublish provides a simple accessor interface to serve xarray objects.
-
-To begin, import xpublish and open an xarray dataset:
+To begin, import Xpublish and open an Xarray dataset:
 
 .. code-block:: python
 
@@ -18,10 +16,23 @@ To begin, import xpublish and open an xarray dataset:
         "air_temperature", chunks=dict(lat=5, lon=5),
     )
 
-Optional customization of the underlying
-`FastAPI application <https://fastapi.tiangolo.com>`_ or the server-side
-`cache <https://github.com/dask/cachey>`_ is possible when the accessor
-is initialized:
+Publishing the dataset above is straightforward, just use the
+:class:`~xpublish.Rest` class:
+
+.. code-block:: python
+
+   rest = xpublish.Rest(ds)
+
+Alternatively, you might want to use the :attr:`xarray.Dataset.rest` accessor
+for more convenience:
+
+.. code-block:: python
+
+    ds.rest
+
+Optional customization of the underlying `FastAPI
+application <https://fastapi.tiangolo.com>`_ or the server-side `cache
+<https://github.com/dask/cachey>`_ is possible, e.g.,
 
 .. code-block:: python
 
@@ -34,10 +45,14 @@ is initialized:
         cache_kws=dict(available_bytes=1e9)
     )
 
-Serving a dataset simply requires calling the :meth:`~xarray.Dataset.rest.serve`
-method on the ``rest`` accessor:
+Serving the dataset then simply requires calling the :meth:`~Rest.serve` method
+on the ``Rest`` instance or the ``rest`` accessor:
 
 .. code-block:: python
+
+    rest.serve()
+
+    # or
 
     ds.rest.serve()
 
@@ -47,8 +62,8 @@ method on the ``rest`` accessor:
 Default API routes
 ~~~~~~~~~~~~~~~~~~
 
-By default, the served application provides the following endpoints to get some
-information about the published dataset:
+By default, the FastAPI application created with Xpublish provides the following
+endpoints to get some information about the published dataset:
 
 * ``/``: returns xarray's HTML repr.
 * ``/keys``: returns a list of variable keys, i.e., those returned by :attr:`xarray.Dataset.variables`.
@@ -68,27 +83,27 @@ Custom API routes
 With Xpublish you have full control on which and how API endpoints are exposed
 by the application.
 
-In the example below, the default API routes are included with additional tags
+In the example below, the default API routes are included with custom tags
 and using a path prefix for Zarr-like data access:
 
 .. code-block:: python
 
-   from xpublish.routers import base_router, common_router, zarr_router
+   from xpublish.routers import base_router, zarr_router
 
    ds.rest(
        routers=[
            (base_router, {'tags': 'info'}),
-           (common_router, {'tags': 'info'}),
-           (zarr_router, {'tags': 'data', 'prefix': '/data'})
+           (zarr_router, {'tags': 'zarr', 'prefix': '/zarr'})
        ]
    )
 
    ds.rest.serve()
 
-Using those settings, Zarr API endpoints now have the following paths:
+Using those settings, the Zarr-specific API endpoints now have the following
+paths:
 
-* ``/data/.zmetadata``
-* ``/data/{var}/{key}``
+* ``/zarr/.zmetadata``
+* ``/zarr/{var}/{key}``
 
 It is also possible to create custom API routes and serve them via Xpublish. In
 the example below, we create a minimal application to get the mean value of a
@@ -126,8 +141,8 @@ like this:
 The :func:`~xpublish.dependencies.get_dataset` function in the example above is
 a FastAPI dependency that is used to access the dataset object being served by
 the application, either from inside a FastAPI path operation decorated function
-or another FastAPI dependency. Note that ``get_dataset`` can only be used as
-function arguments.
+or from another FastAPI dependency. Note that ``get_dataset`` can only be used
+as function arguments.
 
 Xpublish also provides a :func:`~xpublish.dependencies.get_cache` dependency
 function to get/put any useful key-value pair from/into the cache that is
@@ -144,11 +159,53 @@ dictionary argument when initializing the rest accessor.
 
 .. _`Swagger UI`: https://github.com/swagger-api/swagger-ui
 
+Serving multiple datasets
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Xpublish also lets you serve multiple datasets via one FastAPI application. You
+just need to provide a mapping (dictionary) when creating a
+:class:`~xpublish.Rest` instance, e.g.,
+
+.. code-block:: python
+
+    ds2 = xr.tutorial.open_dataset('rasm')
+
+    rest_collection = xpublish.Rest({'air_temperature': ds, 'rasm': ds2})
+
+    rest_collection.serve()
+
+When multiple datasets are given, all dataset-specific API endpoint URLs have
+the ``/datasets/{dataset_id}`` prefix. For example:
+
+* ``/datasets/rasm/info`` returns information about the ``rasm`` dataset
+* ``/datasets/invalid_dataset_id/info`` returns a 404 HTTP error
+
+The application has also one more API endpoint:
+
+* ``/datasets``: returns the list of the ids (keys) of all published datasets
+
+Note that custom routes work for multiple datasets just as well as for a single
+dataset, no code change is required. Taking the example above,
+
+.. code-block:: python
+
+    rest_collection = xpublish.Rest(
+        {'air_temperature': ds, 'rasm': ds2},
+        routers=[myrouter]
+    )
+
+    rest_collection.serve()
+
+The following URLs should return expected results:
+
+* ``/datasets/air_temperature/air/mean``
+* ``/datasets/rasm/Tair/mean``
+
 Client-Side
 -----------
 
-Datasets served by xpublish are can be opened by any Zarr client that
-implements an HTTPStore. In Python, this can be done with ``fsspec``:
+By default, datasets served by Xpublish are can be opened by any Zarr client
+that implements an HTTPStore. In Python, this can be done with ``fsspec``:
 
 .. code-block:: python
 
@@ -156,6 +213,8 @@ implements an HTTPStore. In Python, this can be done with ``fsspec``:
     from fsspec.implementations.http import HTTPFileSystem
 
     fs = HTTPFileSystem()
+
+    # The URL 'http://0.0.0.0:9000' here serves one dataset
     http_map = fs.get_mapper('http://0.0.0.0:9000')
 
     # open as a zarr group

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,7 +77,7 @@ def test_get_data_chunk_numpy_edge_chunk():
     np.testing.assert_equal(data, actual[:2, :])
 
 
-def test_init_twice_raises():
+def test_init_accessor_twice_raises():
     ds = xr.Dataset({'foo': (['x'], [1, 2, 3])})
     ds.rest(app_kws={'foo': 'bar'})
     with pytest.raises(RuntimeError) as excinfo:

--- a/tests/test_fsspec_compat.py
+++ b/tests/test_fsspec_compat.py
@@ -3,7 +3,7 @@ import json
 import pytest
 import xarray as xr
 
-import xpublish  # noqa: F401
+from xpublish import Rest
 from xpublish.utils.zarr import create_zmetadata, jsonify_zmetadata
 
 from .utils import TestMapper
@@ -16,13 +16,13 @@ def airtemp_ds():
 
 
 def test_get_zmetadata_key(airtemp_ds):
-    mapper = TestMapper(airtemp_ds.rest.app)
+    mapper = TestMapper(Rest(airtemp_ds).app)
     actual = json.loads(mapper['.zmetadata'].decode())
     expected = jsonify_zmetadata(airtemp_ds, create_zmetadata(airtemp_ds))
     assert actual == expected
 
 
 def test_missing_key_raises_keyerror(airtemp_ds):
-    mapper = TestMapper(airtemp_ds.rest.app)
+    mapper = TestMapper(Rest(airtemp_ds).app)
     with pytest.raises(KeyError):
         _ = mapper['notakey']

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -172,7 +172,7 @@ def test_cache(airtemp_ds):
 
     response1 = client.get('/air/0.0.0')
     assert response1.status_code == 200
-    assert 'air/0.0.0' in airtemp_ds.rest.cache
+    assert '/air/0.0.0' in airtemp_ds.rest.cache
 
     # test that we can retrieve
     response2 = client.get('/air/0.0.0')

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 from starlette.testclient import TestClient
 
 import xpublish  # noqa: F401
+from xpublish import Rest
 from xpublish.dependencies import get_dataset
 from xpublish.utils.zarr import create_zmetadata, jsonify_zmetadata
 
@@ -15,7 +16,7 @@ def airtemp_ds():
 
 
 @pytest.fixture(scope='function')
-def airtemp_app(airtemp_ds):
+def airtemp_rest(airtemp_ds):
     app_kws = dict(
         title='My Dataset',
         description='Dataset Description',
@@ -23,7 +24,13 @@ def airtemp_app(airtemp_ds):
         openapi_url='/dataset.json',
         docs_url='/data-docs',
     )
-    client = TestClient(airtemp_ds.rest(app_kws=app_kws).app)
+
+    return Rest(airtemp_ds, app_kws=app_kws)
+
+
+@pytest.fixture(scope='function')
+def airtemp_app_client(airtemp_rest):
+    client = TestClient(airtemp_rest.app)
     yield client
 
 
@@ -38,25 +45,28 @@ def dims_router():
     return router
 
 
-def test_rest_config(airtemp_ds):
-    airtemp_ds.rest(cache_kws={'available_bytes': 999})
-    assert airtemp_ds.rest.cache.available_bytes == 999
+def test_init_cache_kws(airtemp_ds):
+    rest = Rest(airtemp_ds, cache_kws={'available_bytes': 999})
+    assert rest.cache.available_bytes == 999
 
 
-def test_init_app(airtemp_ds):
-    airtemp_ds.rest(
+def test_init_app_kws(airtemp_ds):
+    rest = Rest(
+        airtemp_ds,
         app_kws=dict(
             title='My Dataset',
             description='Dataset Description',
             version='1.0.0',
             openapi_url='/dataset.json',
             docs_url='/data-docs',
-        )
+        ),
     )
-    client = TestClient(airtemp_ds.rest.app)
-    assert airtemp_ds.rest.app.title == 'My Dataset'
-    assert airtemp_ds.rest.app.description == 'Dataset Description'
-    assert airtemp_ds.rest.app.version == '1.0.0'
+
+    assert rest.app.title == 'My Dataset'
+    assert rest.app.description == 'Dataset Description'
+    assert rest.app.version == '1.0.0'
+
+    client = TestClient(rest.app)
 
     response = client.get('/dataset.json')
     assert response.status_code == 200
@@ -72,8 +82,8 @@ def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
     else:
         routers = [(dims_router, router_kws)]
 
-    airtemp_ds.rest(routers=routers)
-    client = TestClient(airtemp_ds.rest.app)
+    rest = Rest(airtemp_ds, routers=routers)
+    client = TestClient(rest.app)
 
     response = client.get(path)
     assert response.status_code == 200
@@ -86,7 +96,7 @@ def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
 
 def test_custom_app_routers_error(airtemp_ds):
     with pytest.raises(ValueError, match='Invalid format.*'):
-        airtemp_ds.rest(routers=['not_a_router'])
+        Rest(airtemp_ds, routers=['not_a_router'])
 
 
 def test_custom_app_routers_conflict(airtemp_ds):
@@ -103,78 +113,99 @@ def test_custom_app_routers_conflict(airtemp_ds):
         pass
 
     with pytest.raises(ValueError, match='Found multiple routes.*'):
-        airtemp_ds.rest(routers=[(router1, {'prefix': '/same'}), router2])
+        Rest(airtemp_ds, routers=[(router1, {'prefix': '/same'}), router2])
 
 
-def test_keys(airtemp_ds, airtemp_app):
-    response = airtemp_app.get('/keys')
+def test_keys(airtemp_ds, airtemp_app_client):
+    response = airtemp_app_client.get('/keys')
     assert response.status_code == 200
     assert response.json() == list(airtemp_ds.variables)
 
 
-def test_info(airtemp_ds, airtemp_app):
-    response = airtemp_app.get('/info')
+def test_info(airtemp_ds, airtemp_app_client):
+    response = airtemp_app_client.get('/info')
     assert response.status_code == 200
     json_response = response.json()
     assert json_response['dimensions'] == airtemp_ds.dims
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
 
 
-def test_versions(airtemp_app):
-    response = airtemp_app.get('/versions')
+def test_versions(airtemp_app_client):
+    response = airtemp_app_client.get('/versions')
     assert response.status_code == 200
     assert response.json()['xarray'] == xr.__version__
 
 
-def test_repr(airtemp_ds, airtemp_app):
-    response = airtemp_app.get('/')
+def test_repr(airtemp_ds, airtemp_app_client):
+    response = airtemp_app_client.get('/')
     assert response.status_code == 200
 
 
-def test_zmetadata(airtemp_ds, airtemp_app):
-    response = airtemp_app.get('/.zmetadata')
+def test_zmetadata(airtemp_ds, airtemp_app_client):
+    response = airtemp_app_client.get('/.zmetadata')
     assert response.status_code == 200
     assert response.json() == jsonify_zmetadata(airtemp_ds, create_zmetadata(airtemp_ds))
 
 
-def test_bad_key(airtemp_app):
-    response = airtemp_app.get('/notakey')
+def test_bad_key(airtemp_app_client):
+    response = airtemp_app_client.get('/notakey')
     assert response.status_code == 404
 
 
-def test_zarray(airtemp_app):
-    response = airtemp_app.get('/air/.zarray')
+def test_zarray(airtemp_app_client):
+    response = airtemp_app_client.get('/air/.zarray')
     assert response.status_code == 200
 
 
-def test_zattrs(airtemp_app):
-    response = airtemp_app.get('/air/.zattrs')
+def test_zattrs(airtemp_app_client):
+    response = airtemp_app_client.get('/air/.zattrs')
     assert response.status_code == 200
-    response = airtemp_app.get('/.zattrs')
-    assert response.status_code == 200
-
-
-def test_get_chunk(airtemp_app):
-    response = airtemp_app.get('/air/0.0.0')
+    response = airtemp_app_client.get('/.zattrs')
     assert response.status_code == 200
 
 
-def test_array_group_raises_404(airtemp_app):
-    response = airtemp_app.get('/air/.zgroup')
+def test_get_chunk(airtemp_app_client):
+    response = airtemp_app_client.get('/air/0.0.0')
+    assert response.status_code == 200
+
+
+def test_array_group_raises_404(airtemp_app_client):
+    response = airtemp_app_client.get('/air/.zgroup')
     assert response.status_code == 404
 
 
 def test_cache(airtemp_ds):
-    rest = airtemp_ds.rest(cache_kws={'available_bytes': 1e9})
+    rest = Rest(airtemp_ds, cache_kws={'available_bytes': 1e9})
     assert rest.cache.available_bytes == 1e9
 
     client = TestClient(rest.app)
 
     response1 = client.get('/air/0.0.0')
     assert response1.status_code == 200
-    assert '/air/0.0.0' in airtemp_ds.rest.cache
+    assert '/air/0.0.0' in rest.cache
 
     # test that we can retrieve
     response2 = client.get('/air/0.0.0')
     assert response2.status_code == 200
     assert response1.content == response2.content
+
+
+def test_rest_accessor(airtemp_ds):
+    client = TestClient(airtemp_ds.rest.app)
+
+    # FastAPI default URL for generated docs
+    response = client.get('/docs')
+    assert response.status_code == 200
+
+
+def test_rest_accessor_kws(airtemp_ds):
+    airtemp_ds.rest(
+        app_kws=dict(docs_url='/data-docs'), cache_kws=dict(available_bytes=1e9),
+    )
+
+    assert airtemp_ds.rest.cache.available_bytes == 1e9
+
+    client = TestClient(airtemp_ds.rest.app)
+
+    response = client.get('/data-docs')
+    assert response.status_code == 200

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -94,6 +94,12 @@ def test_init_app_kws(airtemp_ds):
     assert response.status_code == 200
 
 
+@pytest.mark.parametrize('datasets', ['not_a_dataset_obj', {'ds': 'not_a_dataset_obj'}])
+def test_init_dataset_type_error(datasets):
+    with pytest.raises(TypeError, match='Can only publish.*Dataset objects'):
+        Rest(datasets)
+
+
 @pytest.mark.parametrize('router_kws,path', [(None, '/dims'), ({'prefix': '/foo'}, '/foo/dims')])
 def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
     if router_kws is None:
@@ -114,7 +120,7 @@ def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
 
 
 def test_custom_app_routers_error(airtemp_ds):
-    with pytest.raises(ValueError, match='Invalid format.*'):
+    with pytest.raises(TypeError, match='Invalid type/format.*'):
         Rest(airtemp_ds, routers=['not_a_router'])
 
 

--- a/tests/test_zarr_compat.py
+++ b/tests/test_zarr_compat.py
@@ -3,15 +3,9 @@ import json
 import pytest
 import xarray as xr
 
-import xpublish  # noqa: F401
+from xpublish import Rest
 
 from .utils import TestMapper, create_dataset
-
-
-@pytest.fixture(scope='module')
-def airtemp_ds():
-    ds = xr.tutorial.open_dataset('air_temperature')
-    return ds.chunk(dict(ds.dims))
 
 
 @pytest.mark.parametrize(
@@ -37,7 +31,7 @@ def test_zmetadata_identical(start, end, freq, nlats, nlons, var_const, calendar
     ds = ds.chunk(ds.dims)
     zarr_dict = {}
     ds.to_zarr(zarr_dict, consolidated=True)
-    mapper = TestMapper(ds.rest.app)
+    mapper = TestMapper(Rest(ds).app)
     actual = json.loads(mapper['.zmetadata'].decode())
     expected = json.loads(zarr_dict['.zmetadata'].decode())
     assert actual == expected
@@ -64,7 +58,7 @@ def test_roundtrip(start, end, freq, nlats, nlons, var_const, calendar, use_cfti
     )
     ds = ds.chunk(ds.dims)
 
-    mapper = TestMapper(ds.rest.app)
+    mapper = TestMapper(Rest(ds).app)
     actual = xr.open_zarr(mapper, consolidated=True)
 
     xr.testing.assert_identical(actual, ds)
@@ -159,7 +153,7 @@ def test_roundtrip_custom_chunks(
         decode_times=decode_times,
     )
     ds = ds.chunk(chunks)
-    mapper = TestMapper(ds.rest.app)
+    mapper = TestMapper(Rest(ds).app)
     actual = xr.open_zarr(mapper, consolidated=True, decode_times=decode_times)
 
     xr.testing.assert_identical(actual, ds)

--- a/xpublish/__init__.py
+++ b/xpublish/__init__.py
@@ -1,6 +1,6 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
-from .rest import RestAccessor  # noqa: F401
+from .rest import Rest, RestAccessor  # noqa: F401
 
 try:
     __version__ = get_distribution(__name__).version

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -8,7 +8,21 @@ from fastapi import Depends
 from .utils.zarr import create_zmetadata, create_zvariables, zarr_metadata_key
 
 
-def get_dataset():
+def get_dataset_ids():
+    """FastAPI dependency for getting the list of ids (string keys)
+    of the collection of datasets being served.
+
+    Use this callable as dependency in any FastAPI path operation
+    function where you need access to those ids.
+
+    This dummy dependency will be overridden when creating the FastAPI
+    application.
+
+    """
+    return []
+
+
+def get_dataset(dataset_id: str):
     """FastAPI dependency for accessing the published xarray dataset object.
 
     Use this callable as dependency in any FastAPI path operation

--- a/xpublish/dependencies.py
+++ b/xpublish/dependencies.py
@@ -5,6 +5,7 @@ import cachey
 import xarray as xr
 from fastapi import Depends
 
+from .utils.api import DATASET_ID_ATTR_KEY
 from .utils.zarr import create_zmetadata, create_zvariables, zarr_metadata_key
 
 
@@ -54,7 +55,7 @@ def get_zvariables(
 ):
     """FastAPI dependency that returns a dictionary of zarr encoded variables."""
 
-    cache_key = 'zvariables'
+    cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + 'zvariables'
     zvariables = cache.get(cache_key)
 
     if zvariables is None:
@@ -73,12 +74,13 @@ def get_zmetadata(
 ):
     """FastAPI dependency that returns a consolidated zmetadata dictionary. """
 
-    zmeta = cache.get(zarr_metadata_key)
+    cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + zarr_metadata_key
+    zmeta = cache.get(cache_key)
 
     if zmeta is None:
         zmeta = create_zmetadata(dataset)
 
         # we want to permanently cache this: set high cost value
-        cache.put(zarr_metadata_key, zmeta, 99999)
+        cache.put(cache_key, zmeta, 99999)
 
     return zmeta

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -101,22 +101,22 @@ class Rest:
 
     def __init__(self, datasets, routers=None, cache_kws=None, app_kws=None):
 
-        if isinstance(datasets, xr.Dataset):
-            single_dataset = datasets
-            self._datasets = {}
-            self._get_dataset_func = _dataset_unique_getter(single_dataset)
+        self._datasets = normalize_datasets(datasets)
+
+        if not self._datasets:
+            # publish single dataset
+            self._get_dataset_func = _dataset_unique_getter(datasets)
             dataset_route_prefix = ''
         else:
-            self._datasets = normalize_datasets(datasets)
             self._get_dataset_func = _dataset_from_collection_getter(self._datasets)
             dataset_route_prefix = '/datasets/{dataset_id}'
+
+        self._app_routers = _set_app_routers(routers, dataset_route_prefix)
 
         self._app = None
         self._app_kws = {}
         if app_kws is not None:
             self._app_kws.update(app_kws)
-
-        self._app_routers = _set_app_routers(routers, dataset_route_prefix)
 
         self._cache = None
         self._cache_kws = {'available_bytes': 1e6}

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -200,7 +200,7 @@ class RestAccessor:
         Parameters
         ----------
         **kwargs
-            Arguments passed to :func:`Rest.__init__`.
+            Arguments passed to :func:`xpublish.Rest.__init__`.
 
         Notes
         -----
@@ -236,7 +236,7 @@ class RestAccessor:
         Parameters
         ----------
         **kwargs :
-            Arguments passed to :func:`Rest.serve`.
+            Arguments passed to :func:`xpublish.Rest.serve`.
 
         Notes
         -----

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -68,7 +68,7 @@ class Rest:
 
     Parameters
     ----------
-    datasets : xr.Dataset or dict
+    datasets : :class:`xarray.Dataset` or dict
         A single :class:`xarray.Dataset` object or a mapping of datasets objects
         to be served. If a mapping is given, keys are used as dataset ids and
         are converted to strings. See also the notes below.
@@ -99,7 +99,7 @@ class Rest:
 
     """
 
-    def __init__(self, datasets, routers=None, cache_kws=None, app_kws=None, unique=False):
+    def __init__(self, datasets, routers=None, cache_kws=None, app_kws=None):
 
         if isinstance(datasets, xr.Dataset):
             single_dataset = datasets

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -1,84 +1,125 @@
 import cachey
 import uvicorn
 import xarray as xr
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 
-from .dependencies import get_cache, get_dataset
-from .routers import base_router, common_router, zarr_router
-from .utils.api import check_route_conflicts, normalize_app_routers
+from .dependencies import get_cache, get_dataset, get_dataset_ids
+from .routers import base_router, common_router, dataset_collection_router, zarr_router
+from .utils.api import check_route_conflicts, normalize_app_routers, normalize_datasets
 
 
-@xr.register_dataset_accessor('rest')
-class RestAccessor:
-    """REST API Accessor
-
-    Parameters
-    ----------
-    xarray_obj : Dataset
-        Dataset object to be served through the REST API.
-
-    Notes
-    -----
-    When using this as an accessor on an Xarray.Dataset, options are set via
-    the ``RestAccessor.__call__()`` method.
+def _dataset_from_collection_getter(datasets):
+    """Used to override the get_dataset FastAPI dependency in case where
+    a collection of datasets is being served.
 
     """
 
-    def __init__(self, xarray_obj):
+    def get_dataset(dataset_id: str):
+        if dataset_id not in datasets:
+            raise HTTPException(status_code=404, detail=f"Dataset '{dataset_id}' not found")
 
-        self._obj = xarray_obj
+        return datasets[dataset_id]
 
-        self._app = None
-        self._app_kws = {}
-        self._app_routers = [
-            (common_router, {}),
+    return get_dataset
+
+
+def _dataset_unique_getter(dataset):
+    """Used to override the get_dataset FastAPI dependency in case where
+    only one dataset is being served, e.g., via the 'rest' accessor.
+
+    """
+
+    def get_dataset():
+        return dataset
+
+    return get_dataset
+
+
+def _set_app_routers(dataset_routers, unique=False):
+
+    app_routers = []
+
+    # top-level api endpoints
+    app_routers.append((common_router, {}))
+
+    if not unique:
+        app_routers.append((dataset_collection_router, {'tags': ['info']}))
+
+    # dataset-specifc api endpoints
+    if dataset_routers is None:
+        dataset_routers = [
             (base_router, {'tags': ['info']}),
             (zarr_router, {'tags': ['zarr']}),
         ]
 
-        self._cache = None
-        self._cache_kws = {'available_bytes': 1e6}
+    if unique:
+        dataset_route_prefix = ''
+    else:
+        dataset_route_prefix = '/datasets/{dataset_id}'
 
-        self._initialized = False
+    app_routers += normalize_app_routers(dataset_routers, dataset_route_prefix)
 
-    def __call__(self, routers=None, cache_kws=None, app_kws=None):
-        """Initialize this accessor by setting optional configuration values.
+    check_route_conflicts(app_routers)
 
-        Parameters
-        ----------
-        routers : list, optional
-            A list of :class:`fastapi.APIRouter` instances to include in the
-            fastAPI application. If None, the default routers will be included.
-            The items of the list may also be tuples with the following format:
-            ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``.
-            The 1st tuple element is a :class:`fastapi.APIRouter` instance and the
-            2nd element is a dictionary that is used to pass keyword arguments to
-            :meth:`fastapi.FastAPI.include_router`.
-        cache_kws : dict, optional
-            Dictionary of keyword arguments to be passed to
-            :meth:`cachey.Cache.__init__()`.
-        app_kws : dict, optional
-            Dictionary of keyword arguments to be passed to
-            :meth:`fastapi.FastAPI.__init__()`.
+    return app_routers
 
-        Notes
-        -----
-        This method can only be invoked once.
 
-        """
-        if self._initialized:
-            raise RuntimeError('This accessor has already been initialized')
-        self._initialized = True
+class Rest:
+    """Used to publish a collection of xarray Datasets via a REST API (FastAPI application).
 
-        if routers is not None:
-            self._app_routers = normalize_app_routers(routers)
-            check_route_conflicts(self._app_routers)
+    Parameters
+    ----------
+    datasets : dict
+        A collection of datasets to be served. Keys are dataset ids (will be converted to
+        strings) and values must be :class:`xarray.Dataset` objects.
+    routers : list, optional
+        A list of :class:`fastapi.APIRouter` instances to include in the
+        fastAPI application. If None, the default routers will be included.
+        The items of the list may also be tuples with the following format:
+        ``[(router1, {'prefix': '/foo', 'tags': ['foo', 'bar']})]``.
+        The 1st tuple element is a :class:`fastapi.APIRouter` instance and the
+        2nd element is a dictionary that is used to pass keyword arguments to
+        :meth:`fastapi.FastAPI.include_router`.
+    cache_kws : dict, optional
+        Dictionary of keyword arguments to be passed to
+        :meth:`cachey.Cache.__init__()`.
+    app_kws : dict, optional
+        Dictionary of keyword arguments to be passed to
+        :meth:`fastapi.FastAPI.__init__()`.
+    unique : bool, optional
+        If True, the FastAPI application is configured to serve only one dataset,
+        i.e., dataset ids are ignored and are not present as parameters in the
+        API urls (default: False).
+        For more convienence, use the :attr:`xarray.Dataset.rest` accessor instead
+        to publish one dataset.
+
+    """
+
+    def __init__(self, datasets, routers=None, cache_kws=None, app_kws=None, unique=False):
+
+        self._datasets = normalize_datasets(datasets)
+
+        if unique:
+            if len(datasets) != 1:
+                raise ValueError(
+                    'the given collection of datasets must cointain one item when `unique` '
+                    f'is set to True, found {len(datasets)} item(s)'
+                )
+            self._get_dataset_func = _dataset_unique_getter(self._datasets[''])
+        else:
+            self._get_dataset_func = _dataset_from_collection_getter(self._datasets)
+
+        self._app = None
+        self._app_kws = {}
         if app_kws is not None:
             self._app_kws.update(app_kws)
+
+        self._app_routers = _set_app_routers(routers, unique=unique)
+
+        self._cache = None
+        self._cache_kws = {'available_bytes': 1e6}
         if cache_kws is not None:
             self._cache_kws.update(cache_kws)
-
-        return self
 
     @property
     def cache(self) -> cachey.Cache:
@@ -96,7 +137,8 @@ class RestAccessor:
         for rt, kwargs in self._app_routers:
             self._app.include_router(rt, **kwargs)
 
-        self._app.dependency_overrides[get_dataset] = lambda: self._obj
+        self._app.dependency_overrides[get_dataset_ids] = lambda: list(self._datasets)
+        self._app.dependency_overrides[get_dataset] = self._get_dataset_func
         self._app.dependency_overrides[get_cache] = lambda: self.cache
 
         return self._app
@@ -120,7 +162,7 @@ class RestAccessor:
         log_level : str
             App logging level, valid options are
             {'critical', 'error', 'warning', 'info', 'debug', 'trace'}.
-        kwargs :
+        **kwargs :
             Additional arguments to be passed to :func:`uvicorn.run`.
 
         Notes
@@ -129,3 +171,76 @@ class RestAccessor:
 
         """
         uvicorn.run(self.app, host=host, port=port, log_level=log_level, **kwargs)
+
+
+@xr.register_dataset_accessor('rest')
+class RestAccessor:
+    """REST API Accessor for serving one dataset in its
+    dedicated FastAPI application.
+
+    """
+
+    def __init__(self, xarray_obj):
+
+        self._obj = xarray_obj
+        self._datasets = {'': xarray_obj}
+        self._rest = None
+
+        self._initialized = False
+
+    def _get_rest_obj(self):
+        if self._rest is None:
+            self._rest = Rest(self._datasets, unique=True)
+
+        return self._rest
+
+    def __call__(self, **kwargs):
+        """Initialize this accessor by setting optional configuration values.
+
+        Parameters
+        ----------
+        **kwargs
+            Arguments passed to :func:`Rest.__init__`.
+
+        Notes
+        -----
+        This method can only be invoked once.
+
+        """
+        if self._initialized:
+            raise RuntimeError('This accessor has already been initialized')
+        self._initialized = True
+
+        # force serving one unique dataset
+        kwargs['unique'] = True
+
+        self._rest = Rest(self._datasets, **kwargs)
+
+        return self
+
+    @property
+    def cache(self) -> cachey.Cache:
+        """Returns the :class:`cachey.Cache` instance used by the FastAPI application."""
+
+        return self._get_rest_obj().cache
+
+    @property
+    def app(self) -> FastAPI:
+        """Returns the :class:`fastapi.FastAPI` application instance."""
+
+        return self._get_rest_obj().app
+
+    def serve(self, **kwargs):
+        """Serve this FastAPI application via :func:`uvicorn.run`.
+
+        Parameters
+        ----------
+        **kwargs :
+            Arguments passed to :func:`Rest.serve`.
+
+        Notes
+        -----
+        This method is blocking and does not return.
+
+        """
+        self._get_rest_obj().serve(**kwargs)

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -84,6 +84,8 @@ class Rest:
     cache_kws : dict, optional
         Dictionary of keyword arguments to be passed to
         :meth:`cachey.Cache.__init__()`.
+        By default, the cache size is set to 1MB, but this can be changed with
+        ``available_bytes``.
     app_kws : dict, optional
         Dictionary of keyword arguments to be passed to
         :meth:`fastapi.FastAPI.__init__()`.

--- a/xpublish/routers/__init__.py
+++ b/xpublish/routers/__init__.py
@@ -1,3 +1,3 @@
 from .base import base_router
-from .common import common_router
+from .common import common_router, dataset_collection_router
 from .zarr import zarr_router

--- a/xpublish/routers/common.py
+++ b/xpublish/routers/common.py
@@ -5,8 +5,9 @@ Dataset-independent API routes.
 import importlib
 import sys
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from ..dependencies import get_dataset_ids
 from ..utils.info import get_sys_info, netcdf_and_hdf5_versions
 
 common_router = APIRouter()
@@ -37,3 +38,11 @@ def get_versions():
         except ImportError:
             pass
     return versions
+
+
+dataset_collection_router = APIRouter()
+
+
+@dataset_collection_router.get('/datasets')
+def get_dataset_collection_keys(ids: list = Depends(get_dataset_ids)):
+    return ids

--- a/xpublish/routers/zarr.py
+++ b/xpublish/routers/zarr.py
@@ -8,6 +8,7 @@ from starlette.responses import Response
 from zarr.storage import array_meta_key, attrs_key, group_meta_key
 
 from ..dependencies import get_cache, get_dataset, get_zmetadata as _get_zmetadata, get_zvariables
+from ..utils.api import DATASET_ID_ATTR_KEY
 from ..utils.cache import CostTimer
 from ..utils.zarr import encode_chunk, get_data_chunk, jsonify_zmetadata, zarr_metadata_key
 
@@ -41,6 +42,7 @@ def get_zattrs(zmetadata: dict = Depends(_get_zmetadata)):
 def get_variable_chunk(
     var: str,
     chunk: str,
+    dataset: xr.Dataset = Depends(get_dataset),
     cache: cachey.Cache = Depends(get_cache),
     zvariables: dict = Depends(get_zvariables),
     zmetadata: dict = Depends(_get_zmetadata),
@@ -61,7 +63,7 @@ def get_variable_chunk(
         logger.debug('var is %s', var)
         logger.debug('chunk is %s', chunk)
 
-        cache_key = f'{var}/{chunk}'
+        cache_key = dataset.attrs.get(DATASET_ID_ATTR_KEY, '') + '/' + f'{var}/{chunk}'
         response = cache.get(cache_key)
 
         if response is None:

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -1,15 +1,37 @@
+from typing import Dict, List, Tuple
+
+import xarray as xr
 from fastapi import APIRouter
 
+DATASET_ID_ATTR_KEY = '_xpublish_id'
 
-def normalize_app_routers(routers):
 
+def normalize_datasets(datasets) -> Dict[str, xr.Dataset]:
+    """Normalize the given collection of datasets.
+
+    - convert all keys (dataset ids) to strings
+    - add dataset ids to their corresponding dataset object as global attribute
+      (so that it can be easily retrieved within path operation functions).
+
+    """
+    return {str(k): ds.assign_attrs({DATASET_ID_ATTR_KEY: k}) for k, ds in datasets.items()}
+
+
+def normalize_app_routers(routers: list, prefix: str) -> List[Tuple[APIRouter, Dict]]:
+    """Normalise the given list of routers.
+
+    Add or prepend ``prefix`` to all routers.
+
+    """
     new_routers = []
 
     for rt in routers:
         if isinstance(rt, APIRouter):
-            new_routers.append((rt, {}))
+            new_routers.append((rt, {'prefix': prefix}))
         elif isinstance(rt, tuple) and isinstance(rt[0], APIRouter) and len(rt) == 2:
-            new_routers.append(rt)
+            rt_kwargs = rt[1]
+            rt_kwargs['prefix'] = prefix + rt_kwargs.get('prefix', '')
+            new_routers.append((rt[0], rt_kwargs))
         else:
             raise ValueError(
                 'Invalid format for routers item, please provide either an APIRouter '

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Dict, List, Tuple
 
 import xarray as xr
@@ -9,16 +10,27 @@ DATASET_ID_ATTR_KEY = '_xpublish_id'
 def normalize_datasets(datasets) -> Dict[str, xr.Dataset]:
     """Normalize the given collection of datasets.
 
+    - raise TypeError if objects other than xarray.Dataset are found
+    - return an empty dictionary in the special case where a single dataset is given
     - convert all keys (dataset ids) to strings
     - add dataset ids to their corresponding dataset object as global attribute
       (so that it can be easily retrieved within path operation functions).
 
     """
-    return {str(k): ds.assign_attrs({DATASET_ID_ATTR_KEY: k}) for k, ds in datasets.items()}
+    error_msg = 'Can only publish a xarray.Dataset object or a mapping of Dataset objects'
+
+    if isinstance(datasets, xr.Dataset):
+        return {}
+    elif isinstance(datasets, Mapping):
+        if not all([isinstance(obj, xr.Dataset) for obj in datasets.values()]):
+            raise TypeError(error_msg)
+        return {str(k): ds.assign_attrs({DATASET_ID_ATTR_KEY: k}) for k, ds in datasets.items()}
+    else:
+        raise TypeError(error_msg)
 
 
 def normalize_app_routers(routers: list, prefix: str) -> List[Tuple[APIRouter, Dict]]:
-    """Normalise the given list of routers.
+    """Normalise the given list of (dataset-specific) API routers.
 
     Add or prepend ``prefix`` to all routers.
 
@@ -33,8 +45,8 @@ def normalize_app_routers(routers: list, prefix: str) -> List[Tuple[APIRouter, D
             rt_kwargs['prefix'] = prefix + rt_kwargs.get('prefix', '')
             new_routers.append((rt[0], rt_kwargs))
         else:
-            raise ValueError(
-                'Invalid format for routers item, please provide either an APIRouter '
+            raise TypeError(
+                'Invalid type/format for routers argument, please provide either an APIRouter '
                 'instance or a (APIRouter, {...}) tuple.'
             )
 

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -10,6 +10,8 @@ from zarr.meta import encode_fill_value
 from zarr.storage import array_meta_key, attrs_key, default_compressor, group_meta_key
 from zarr.util import normalize_shape
 
+from .api import DATASET_ID_ATTR_KEY
+
 try:
     from xarray.backends.zarr import (
         DIMENSION_KEY,
@@ -38,6 +40,10 @@ def _extract_dataset_zattrs(dataset: xr.Dataset):
     zattrs = {}
     for k, v in dataset.attrs.items():
         zattrs[k] = encode_zarr_attr_value(v)
+
+    # remove xpublish internal attribute
+    zattrs.pop(DATASET_ID_ATTR_KEY, None)
+
     return zattrs
 
 


### PR DESCRIPTION
Closes #23.

It took me a bit longer than I thought to implement this.

TODO:

- [x] add tests
- [x] update docs

---

This PR adds a top-level ``Rest`` class that has the same interface than the `Dataset.rest` accessor. Actually, the accessor now internally reuses this class and is just there for convenience:

```python
ds.rest.serve()
```

is equivalent to

```python
# my_collection = {'': ds}

# Rest(my_collection, unique=True).serve()

# EDIT:
Rest(ds).serve()
```

When ~~``unique=False``~~ a mapping of datasets is given to `Rest.__init__`, all dataset-specific api endoints have the prefix ``/datasets/{dataset_id}``. There is also another endpoint ``/datasets`` that returns a list of all dataset ids. When ~~``unique=True``~~ a single dataset is given the behavior stays unchanged compared to the current one.


Some other remarks on the implementation:

- All the datasets in the published collection have an extra, xpublish-reserved global attribute for storing their id. This doesn't affects the original datasets (attributes are added on shallow copies) and it is not returned in the API results. I haven't found any better solution to access the dataset `id` (useful for setting cache keys) from within a path operation function than via the `get_dataset` dependency.

- One thing that is still a bit annoying is the `dataset_id` field still required in the generated API docs when serving a single dataset (see https://github.com/tiangolo/fastapi/issues/1594). This is only minor annoyance, though, the API works as expected and hopefully this issue will be fixed at some point.


