### PR TITLE
update the package url for sphinx-autosummary-accessors

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx_copybutton
-git+https://github.com/keewis/sphinx-autosummary-accessors
+git+https://github.com/xarray-contrib/sphinx-autosummary-accessors

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -66,7 +66,7 @@ tools:
 
 - `Sphinx <https://github.com/sphinx-doc/sphinx>`__
 - `sphinx_rtd_theme <https://github.com/readthedocs/sphinx_rtd_theme>`__
-- `sphinx-autosummary-accessors <https://github.com/keewis/sphinx-autosummary-accessors>`__
+- `sphinx-autosummary-accessors <https://github.com/xarray-contrib/sphinx-autosummary-accessors>`__
 
 You can then build the documentation with the following commands::
 


### PR DESCRIPTION
I just moved `sphinx-autosummary-accessors` from my own organization to `xarray-contrib`. Since right now it's only used by the repositories in `xarray-contrib` I can afford to submit PRs to all of them :grinning:

Not sure when I can release that extension and upload to PyPI / conda-forge (that is blocked by issues with `AccessorCallable` in combination with `autosummary` – once fixed the `alias of ...` summary will be replaced by the summary line in the `__call__` docstring), but once I do I'll ping you.