### PR TITLE
Update URL of sphinx-autosummary-accessors repo

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx_copybutton
-git+https://github.com/keewis/sphinx-autosummary-accessors
+git+https://github.com/xarray-contrib/sphinx-autosummary-accessors

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -66,7 +66,7 @@ tools:
 
 - `Sphinx <https://github.com/sphinx-doc/sphinx>`__
 - `sphinx_rtd_theme <https://github.com/readthedocs/sphinx_rtd_theme>`__
-- `sphinx-autosummary-accessors <https://github.com/keewis/sphinx-autosummary-accessors>`__
+- `sphinx-autosummary-accessors <https://github.com/xarray-contrib/sphinx-autosummary-accessors>`__
 
 You can then build the documentation with the following commands::
 


### PR DESCRIPTION
As it has moved to the `xarray-contrib` organization.