### PR TITLE
use the released version from pypi

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
 sphinx_copybutton
-git+https://github.com/xarray-contrib/sphinx-autosummary-accessors
+sphinx-autosummary-accessors

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx>=3.1
 sphinx_copybutton
 sphinx-autosummary-accessors


### PR DESCRIPTION
I just released `sphinx-autosummary-accessors` 0.1, so that should be preferred over installing from github. This also pins `sphinx` to `sphinx>=3.1` which fixes the incomplete summary for callable accessors.