### PR TITLE
Fix single dataset openapi specs (API docs)

### DIFF
--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -275,6 +275,13 @@ def test_ds_dict_cache(ds_dict):
     assert 'ds2/.zmetadata' in rest.cache
 
 
+def test_single_dataset_openapi_override(airtemp_rest):
+    openapi_schema = airtemp_rest.app.openapi()
+
+    # "dataset_id" parameter should be absent in all paths
+    assert len(openapi_schema['paths']['/']['get']['parameters']) == 0
+
+
 def test_serve(airtemp_rest, mocker):
     kwargs = dict(host='0.0.0.0', log_level='debug', port=9000)
     mocker.patch('uvicorn.run')

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -281,6 +281,10 @@ def test_single_dataset_openapi_override(airtemp_rest):
     # "dataset_id" parameter should be absent in all paths
     assert len(openapi_schema['paths']['/']['get']['parameters']) == 0
 
+    # test cached value
+    openapi_schema = airtemp_rest.app.openapi()
+    assert len(openapi_schema['paths']['/']['get']['parameters']) == 0
+
 
 def test_serve(airtemp_rest, mocker):
     kwargs = dict(host='0.0.0.0', log_level='debug', port=9000)

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -5,7 +5,12 @@ from fastapi import FastAPI, HTTPException
 
 from .dependencies import get_cache, get_dataset, get_dataset_ids
 from .routers import base_router, common_router, dataset_collection_router, zarr_router
-from .utils.api import check_route_conflicts, normalize_app_routers, normalize_datasets
+from .utils.api import (
+    SingleDatasetOpenAPIOverrider,
+    check_route_conflicts,
+    normalize_app_routers,
+    normalize_datasets,
+)
 
 
 def _dataset_from_collection_getter(datasets):
@@ -144,6 +149,10 @@ class Rest:
         self._app.dependency_overrides[get_dataset_ids] = lambda: list(self._datasets)
         self._app.dependency_overrides[get_dataset] = self._get_dataset_func
         self._app.dependency_overrides[get_cache] = lambda: self.cache
+
+        if not self._datasets:
+            # fix openapi spec for single dataset
+            self._app.openapi = SingleDatasetOpenAPIOverrider(self._app).openapi
 
         return self._app
 

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 
 import xarray as xr
 from fastapi import APIRouter
+from fastapi.openapi.utils import get_openapi
 
 DATASET_ID_ATTR_KEY = '_xpublish_id'
 
@@ -72,3 +73,67 @@ def check_route_conflicts(routers):
 
     if len(duplicates):
         raise ValueError(f'Found multiple routes defined for the following paths: {duplicates}')
+
+
+class SingleDatasetOpenAPIOverrider:
+    """Used to override the FastAPI application openapi specs when a single
+    dataset is published.
+
+    In this case, the "dataset_id" path parameter is not present in API
+    endpoints and has to be removed manually.
+
+    See:
+
+    - https://fastapi.tiangolo.com/advanced/extending-openapi/
+    - https://github.com/tiangolo/fastapi/issues/1594
+
+    """
+
+    def __init__(self, app):
+        self._app = app
+
+    def openapi(self, *args):
+
+        if self._app.openapi_schema:
+            return self._app.openapi_schema
+
+        kwargs = dict(
+            title=self._app.title,
+            version=self._app.version,
+            description=self._app.description,
+            routes=self._app.routes,
+        )
+
+        # TODO: remove when required fastapi min version >= 0.56.0
+        openapi_prefix = getattr(self._app, 'openapi_prefix', None)
+        if openapi_prefix is not None:
+            kwargs.update(openapi_prefix=self._app.openapi_prefix)
+
+        # TODO: remove 'if' when required fastapi min version >= 0.57.0
+        tags = getattr(self._app, 'openapi_tags', None)
+        if tags is not None:
+            kwargs['tags'] = tags
+
+        # TODO: remove 'if' when required fastapi min version >= 0.58.0
+        servers = getattr(self._app, 'servers', None)
+        if servers is not None:
+            kwargs['servers'] = servers
+
+        # TODO: remove when required fastapi min version >= 0.59.0
+        if len(args):
+            kwargs.update(openapi_prefix=args[0])
+
+        openapi_schema = get_openapi(**kwargs)
+
+        for path in openapi_schema.get('paths', {}).values():
+            for http_method in path.values():
+                params = http_method.get('parameters')
+
+                if params is not None:
+                    for i, p in enumerate(params):
+                        if p.get('name') == 'dataset_id':
+                            params.pop(i)
+
+        self._app.openapi_schema = openapi_schema
+
+        return self._app.openapi_schema

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -92,7 +92,7 @@ class SingleDatasetOpenAPIOverrider:
     def __init__(self, app):
         self._app = app
 
-    def openapi(self, *args):
+    def openapi(self):
 
         if self._app.openapi_schema:
             return self._app.openapi_schema
@@ -102,26 +102,9 @@ class SingleDatasetOpenAPIOverrider:
             version=self._app.version,
             description=self._app.description,
             routes=self._app.routes,
+            tags=self._app.openapi_tags,
+            servers=self._app.servers,
         )
-
-        # TODO: remove when required fastapi min version >= 0.56.0
-        openapi_prefix = getattr(self._app, 'openapi_prefix', None)
-        if openapi_prefix is not None:
-            kwargs.update(openapi_prefix=self._app.openapi_prefix)
-
-        # TODO: remove 'if' when required fastapi min version >= 0.57.0
-        tags = getattr(self._app, 'openapi_tags', None)
-        if tags is not None:
-            kwargs['tags'] = tags
-
-        # TODO: remove 'if' when required fastapi min version >= 0.58.0
-        servers = getattr(self._app, 'servers', None)
-        if servers is not None:
-            kwargs['servers'] = servers
-
-        # TODO: remove when required fastapi min version >= 0.59.0
-        if len(args):
-            kwargs.update(openapi_prefix=args[0])
 
         openapi_schema = get_openapi(**kwargs)
 


### PR DESCRIPTION
This fixes FastAPI's generated API docs in the case where a single dataset is published. The `dataset_id` parameter is not shown anymore.

The fix is based on FastAPI docs: https://fastapi.tiangolo.com/advanced/extending-openapi/. I had to do some tricks to support a bunch of changes in last FastAPI versions, though. Hopefully it won't change too often in the future.

This fix won't be needed anymore if it is addressed upstream (see https://github.com/tiangolo/fastapi/issues/1594).  