### PR TITLE
🐛Do not fail if not a git repo when retrieving system information

### DIFF
--- a/xpublish/utils/info.py
+++ b/xpublish/utils/info.py
@@ -35,7 +35,7 @@ def get_sys_info():
                     pass
                 commit = commit.strip().strip('"')
 
-    blob.append(('commit', commit))
+        blob.append(('commit', commit))
 
     uname = platform.uname()
     blob.extend(


### PR DESCRIPTION
otherwise this may happen  on the /versions route:

```
  File "/home/mah/.local/lib/python3.7/site-packages/xpublish/utils/info.py", line 38, in get_sys_info
    blob.append(('commit', commit))
UnboundLocalError: local variable 'commit' referenced before assignment
```