### PR TITLE
Fix tests with last Xarray versions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 fsspec
 netcdf4
+pooch
 pytest
 pytest-mock
 pytest-sugar


### PR DESCRIPTION
I guess the failing roundtrip tests are related to https://github.com/pydata/xarray/pull/2844 but I'm not sure what to do here to fix it. Any idea @jhamman @andersy005?