### PR TITLE
Import dask.array to access to array functions

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 fsspec
+httpx
 netcdf4
 pooch
 pytest

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 
-import dask
+import dask.array
 import numpy as np
 import xarray as xr
 from numcodecs.compat import ensure_ndarray


### PR DESCRIPTION
Xpublish is currently failing as Dask array functions need to be explicitly imported as `import dask.array` rather than being accessible via `import dask`.

Closes #135