### PR TITLE
Don't mutate cached data in DatasetInfoPlugin

### DIFF
--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -236,6 +236,13 @@ def test_info(airtemp_ds, airtemp_app_client):
     assert json_response['dimensions'] == airtemp_ds.dims
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
 
+    # Second request, to make sure the cached data wasn't changed
+    response = airtemp_app_client.get('/info')
+    assert response.status_code == 200
+    json_response = response.json()
+    assert json_response['dimensions'] == airtemp_ds.dims
+    assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
+
 
 def test_dict(airtemp_ds, airtemp_app_client):
     response = airtemp_app_client.get('/dict')

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -57,7 +57,7 @@ class DatasetInfoPlugin(Plugin):
             meta = zmetadata['metadata']
 
             for name, var in zvariables.items():
-                attrs = meta[f'{name}/{attrs_key}']
+                attrs = meta[f'{name}/{attrs_key}'].copy()
                 attrs.pop('_ARRAY_DIMENSIONS')
                 info['variables'][name] = {
                     'type': var.data.dtype.name,


### PR DESCRIPTION
Multiple requests to the /info endpoint are failing. The DatasetInfoPlugin is changing the cached metadata by removing the `_ARRAY_DIMENSIONS` attribute key which is required on subsequent calls. I did not dive into the caching internals to figure out why the value is mutable at all. If it is a simple dict on the backend, the returned cache values could be being changed inside the cache dict itself.

Added a test that fails without the change!