### PR TITLE
Allow plugins sharing the same name to be overwritten

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     setup_requires=['setuptools_scm>=3.4', 'setuptools>=42'],
     entry_points={
         'xpublish.plugin': [
-            'info = xpublish.plugins.included.dataset_info:DatasetInfoPlugin',
+            'dataset_info = xpublish.plugins.included.dataset_info:DatasetInfoPlugin',
             'zarr = xpublish.plugins.included.zarr:ZarrPlugin',
             'module_version = xpublish.plugins.included.module_version:ModuleVersionPlugin',
             'plugin_info = xpublish.plugins.included.plugin_info:PluginInfoPlugin',

--- a/tests/test_plugin_management.py
+++ b/tests/test_plugin_management.py
@@ -1,3 +1,4 @@
+import pytest
 from starlette.testclient import TestClient
 
 from xpublish import Rest
@@ -30,6 +31,46 @@ def test_configure_plugins(airtemp_ds):
     client = TestClient(app)
 
     info_response = client.get('/datasets/airtemp/meta/info')
+    json_response = info_response.json()
+    assert json_response['dimensions'] == airtemp_ds.dims
+    assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
+
+
+def test_overwrite_plugins(airtemp_ds):
+    from xpublish.plugins.included.dataset_info import DatasetInfoPlugin
+
+    # Test discoverable plugins
+    info = DatasetInfoPlugin()
+    rest = Rest({'airtemp': airtemp_ds}, plugins={'info': info})
+
+    # Registering a duplicate plugin name will fail
+    same_name = DatasetInfoPlugin(name='info', dataset_router_prefix='/newinfo')
+    with pytest.raises(ValueError):
+        rest.register_plugin(same_name)
+
+    # Register with overwrite
+    rest.register_plugin(same_name, overwrite=True)
+
+    # Change the name of the plugin
+    new_name = DatasetInfoPlugin(name='meta', dataset_router_prefix='/newmeta')
+    rest.register_plugin(new_name)
+
+    # Registering a duplicate plugin name will fail
+    new_prefix = DatasetInfoPlugin(name='meta', dataset_router_prefix='/meta')
+    with pytest.raises(ValueError):
+        rest.register_plugin(new_prefix)
+
+    app = rest.app
+    client = TestClient(app)
+
+    # Original plugin shouldn't respond... it's gone
+    assert client.get('/datasets/airtemp/info').status_code == 404
+
+    # # Original plugin shouldn't respond... it's gone
+    # assert client.get('/datasets/airtemp/meta').status_code == 200
+
+    # New plugin should respond correctly
+    info_response = client.get('/datasets/airtemp/newmeta/info')
     json_response = info_response.json()
     assert json_response['dimensions'] == airtemp_ds.dims
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())

--- a/tests/test_plugin_management.py
+++ b/tests/test_plugin_management.py
@@ -9,21 +9,21 @@ def test_exclude_plugins():
     found_plugins = manage.find_default_plugins(exclude_plugins=['zarr'])
 
     assert 'zarr' not in found_plugins
-    assert 'info' in found_plugins
+    assert 'dataset_info' in found_plugins
 
 
 def test_configure_plugins(airtemp_ds):
     info_prefix = '/meta'
     zarr_prefix = '/zarr'
     config = {
-        'info': {'dataset_router_prefix': info_prefix},
+        'dataset_info': {'dataset_router_prefix': info_prefix},
         'zarr': {'dataset_router_prefix': zarr_prefix},
     }
     found_plugins = manage.find_default_plugins()
 
     configured_plugins = manage.configure_plugins(found_plugins, config)
 
-    assert configured_plugins['info'].dataset_router_prefix == info_prefix
+    assert configured_plugins['dataset_info'].dataset_router_prefix == info_prefix
     assert configured_plugins['zarr'].dataset_router_prefix == zarr_prefix
 
     rest = Rest({'airtemp': airtemp_ds}, plugins=configured_plugins)
@@ -41,10 +41,10 @@ def test_overwrite_plugins(airtemp_ds):
 
     # Test discoverable plugins
     info = DatasetInfoPlugin()
-    rest = Rest({'airtemp': airtemp_ds}, plugins={'info': info})
+    rest = Rest({'airtemp': airtemp_ds}, plugins={'dataset_info': info})
 
     # Registering a duplicate plugin name will fail
-    same_name = DatasetInfoPlugin(name='info', dataset_router_prefix='/newinfo')
+    same_name = DatasetInfoPlugin(name='dataset_info', dataset_router_prefix='/newinfo')
     with pytest.raises(ValueError):
         rest.register_plugin(same_name)
 

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -267,7 +267,7 @@ def test_plugin_versions(airtemp_app_client):
 
     plugins = response.json()
 
-    assert plugins['info']['version'] == xpublish.__version__
+    assert plugins['dataset_info']['version'] == xpublish.__version__
 
 
 def test_plugins_loaded(airtemp_app_client):
@@ -276,7 +276,7 @@ def test_plugins_loaded(airtemp_app_client):
 
     plugins = response.json()
 
-    assert 'info' in plugins
+    assert 'dataset_info' in plugins
     assert 'module_version' in plugins
     assert 'plugin_info' in plugins
     assert 'zarr' in plugins

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -124,11 +124,35 @@ class Rest:
         for hookspec in self.pm.hook.register_hookspec():
             self.pm.add_hookspecs(hookspec)
 
-    def register_plugin(self, plugin: Plugin, plugin_name: Optional[str] = None):
-        """Register a plugin"""
+    def register_plugin(
+        self, plugin: Plugin, plugin_name: Optional[str] = None, overwrite: bool = False
+    ):
+        """
+        Register a plugin with the xpublish system
+
+        Args:
+            plugin (Plugin): Instantiated Plugin object
+            plugin_name (str, optional): Plugin name
+            overwrite (bool, optional): If a plugin of the same name exist,
+                setting this to True will remove the existing plugin before
+                registering the new plugin. Defaults to False.
+
+        Raises:
+            AttributeError: Plugin can not be registered
+            ValueError: Plugin already registered, try setting overwrite to True
+        """
+        plugin_name = plugin_name or plugin.name
+
+        if overwrite is True and plugin_name in dict(self.pm.list_name_plugin()):
+            # If a plugin exist with the same name, unregister it.
+            # If configured using entry_points, the name of the
+            # entry_point should be the same as the plugin.name.
+            self.pm.unregister(name=plugin_name)
+
+        # Get existing plugins again
         existing_plugins = self.pm.get_plugins()
         try:
-            self.pm.register(plugin, plugin_name or plugin.name)
+            self.pm.register(plugin, plugin_name)
         except AttributeError as e:
             raise AttributeError(
                 f'Plugin {plugin} is likely not initialized before registration'


### PR DESCRIPTION
When configuring an `xpublish` server, I found it useful to be able to load the default entrypoint plugins and override a subset of them. For example, I didn't want the `zarr` plugin in the root namespace, I'd like it at `/zarr`. This allows plugins to be overwritten by name while still allowing `xpublish` to do its thing and discover entrypoint plugins.

```
rest = xpublish.Rest(ds)
zp = ZarrPlugin(dataset_router_prefix='/zarr')
rest.register_plugin(zp, overwrite=True)
```

While testing this I realized that `DatasetInfoPlugin.name = 'dataset_info'` but it was being added in `entrypoints` with the name `info`. There is no problem with this, except when a user like me wants to override the settings of a plugin by name :laughing:  and depending on how it was loaded, the default name changes. I changed the entrypoint to `dataset_info`... not going to die on this hill but it would be nice if the entrypoint name and the default plugin name were equal!