### PR TITLE
Add TypeError on single dataset

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,6 +22,17 @@ def test_dask_chunks_become_zarr_chunks():
     assert zmeta['metadata']['bar/.zarray']['chunks'] == list(data2.shape)
 
 
+def test_single_dataset_raise(airtemp_ds):
+    """A single dataset should throw a TypeError if it's passed to
+    xpublish.Rest rather than xpublish.SingleDatasetRest.
+    """
+    with pytest.raises(TypeError) as excinfo:
+        xpublish.Rest(airtemp_ds)
+    excinfo.match(
+        'xpublish.Rest no longer directly handles single datasets. Please use xpublish.SingleDatasetRest instead'
+    )
+
+
 def test_invalid_dask_chunks_raise():
     data1 = dask.array.zeros((10, 20, 30), chunks=(4, 10, 1))
     data2 = dask.array.zeros((10, 20, 30), chunks=(4, 5, 1))

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -108,13 +108,13 @@ def hook_implementation_plugin():
 
 
 def test_init_cache_kws(airtemp_ds):
-    rest = Rest(airtemp_ds, cache_kws={'available_bytes': 999})
+    rest = Rest({'airtemp': airtemp_ds}, cache_kws={'available_bytes': 999})
     assert rest.cache.available_bytes == 999
 
 
 def test_init_app_kws(airtemp_ds):
     rest = Rest(
-        airtemp_ds,
+        {'airtemp': airtemp_ds},
         app_kws=dict(
             title='My Dataset',
             description='Dataset Description',
@@ -164,7 +164,7 @@ def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
 
 def test_custom_app_routers_error(airtemp_ds):
     with pytest.raises(TypeError, match='Invalid type/format.*'):
-        Rest(airtemp_ds, routers=['not_a_router'])
+        Rest({'airtemp': airtemp_ds}, routers=['not_a_router'])
 
 
 def test_custom_app_routers_conflict(airtemp_ds):
@@ -181,7 +181,7 @@ def test_custom_app_routers_conflict(airtemp_ds):
         pass
 
     with pytest.raises(ValueError, match='Found multiple routes.*'):
-        Rest(airtemp_ds, routers=[(router1, {'prefix': '/same'}), router2])
+        Rest({'airtemp': airtemp_ds}, routers=[(router1, {'prefix': '/same'}), router2])
 
 
 def test_custom_dataset_plugin(airtemp_ds, dataset_plugin):

--- a/xpublish/rest.py
+++ b/xpublish/rest.py
@@ -74,6 +74,11 @@ class Rest:
         app_kws: Optional[Dict] = None,
         plugins: Optional[Dict[str, Plugin]] = None,
     ):
+        if isinstance(datasets, xr.Dataset):
+            raise TypeError(
+                'xpublish.Rest no longer directly handles single datasets. Please use xpublish.SingleDatasetRest instead'
+            )
+
         self.setup_datasets(datasets or {})
         self.setup_plugins(plugins)
 


### PR DESCRIPTION
If a single dataset is passed to `xpublish.Rest` it now throws a `TypeError` directing the user to use `xpublish.SingleDatasetRest`.

I also found a few tests that were testing other things, but were passing a single dataset to `xpublish.Rest`.

Closes #149