### PR TITLE
Encode coords for zarr router

### DIFF
--- a/tests/test_zarr_compat.py
+++ b/tests/test_zarr_compat.py
@@ -41,6 +41,34 @@ def test_zmetadata_identical(start, end, freq, nlats, nlons, var_const, calendar
 @pytest.mark.parametrize(
     'start, end, freq, nlats, nlons, var_const, calendar, use_cftime',
     [
+        ('2018-01-01', '2021-01-01', 'MS', 15, 30, True, 'standard', False),
+    ],
+)
+def test_zmetadata_identical_coords(start, end, freq, nlats, nlons, var_const, calendar, use_cftime):
+    ds = create_dataset(
+        start=start,
+        end=end,
+        freq=freq,
+        nlats=nlats,
+        nlons=nlons,
+        var_const=var_const,
+        use_cftime=use_cftime,
+        calendar=calendar,
+        use_xy_dim=True
+    )
+
+    ds = ds.chunk(ds.dims)
+    zarr_dict = {}
+    ds.to_zarr(zarr_dict, consolidated=True)
+    mapper = TestMapper(SingleDatasetRest(ds).app)
+    actual = json.loads(mapper['.zmetadata'].decode())
+    expected = json.loads(zarr_dict['.zmetadata'].decode())
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    'start, end, freq, nlats, nlons, var_const, calendar, use_cftime',
+    [
         ('2018-01-01', '2021-01-01', 'MS', 180, 360, True, 'standard', False),
         ('2018-01-01', '2021-01-01', 'D', 180, 360, False, 'noleap', True),
         ('2018-01-01', '2021-01-01', '6H', 180, 360, True, 'gregorian', False),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -45,6 +45,7 @@ def create_dataset(
     nlats=1,
     nlons=1,
     var_const=None,
+    use_xy_dim=False,
 ):
     """Utility function for creating test data"""
 
@@ -91,7 +92,12 @@ def create_dataset(
     lats = np.linspace(start=-90, stop=90, num=nlats, dtype='float32')
     lons = np.linspace(start=-180, stop=180, num=nlons, dtype='float32')
 
-    shape = (times.size, lats.size, lons.size)
+    if use_xy_dim:
+        lats, lons = np.meshgrid(lats, lons)
+        shape = (times.size, *lats.shape)
+    else: 
+        shape = (times.size, lats.size, lons.size)
+
     num = reduce(mul, shape)
 
     if var_const is None:
@@ -113,14 +119,22 @@ def create_dataset(
     ds = xr.Dataset(
         {
             'tmin': xr.DataArray(
-                tmin_values.astype('float32'), dims=('time', 'lat', 'lon'), name='tmin'
+                tmin_values.astype('float32'), 
+                dims=('time', 'lat', 'lon') if not use_xy_dim else ('time', 'y', 'x'),
+                name='tmin'
             ),
             'tmax': xr.DataArray(
-                tmax_values.astype('float32'), dims=('time', 'lat', 'lon'), name='tmax'
+                tmax_values.astype('float32'),
+                dims=('time', 'lat', 'lon') if not use_xy_dim else ('time', 'y', 'x'),
+                name='tmax'
             ),
             'time_bounds': time_bounds,
         },
-        {'time': times, 'lat': lats, 'lon': lons},
+        coords={
+            'time': times, 
+            'lat': ('lat' if not use_xy_dim else ['y', 'x'], lats), 
+            'lon': ('lon' if not use_xy_dim else ['y', 'x'], lons)
+        },
     )
 
     ds.tmin.encoding['_FillValue'] = np.float32(-9999999)

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -111,10 +111,10 @@ def create_zmetadata(dataset):
     zmeta['metadata'][group_meta_key] = {'zarr_format': zarr_format}
     zmeta['metadata'][attrs_key] = _extract_dataset_zattrs(dataset)
 
-    for key in dataset.variables.keys():
+    for key, dvar in dataset.variables.items():
         da = dataset[key]
-        encoded_da = encode_zarr_variable(da, name=key)
-        encoding = extract_zarr_variable_encoding(da)
+        encoded_da = encode_zarr_variable(dvar, name=key)
+        encoding = extract_zarr_variable_encoding(dvar)
         zattrs = _extract_dataarray_zattrs(encoded_da)
         zattrs = _extract_dataarray_coords(da, zattrs)
         zmeta['metadata'][f'{key}/{attrs_key}'] = zattrs

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -53,7 +53,7 @@ def _extract_dataarray_zattrs(da):
 
 def _extract_dataarray_coords(da, zattrs):
     '''helper function to extract coords from DataArray into a directionary'''
-    if da.coords: 
+    if da.coords:
         # Coordinates are only encoded if there are non-dimension coordinates
         nondim_coords = set(da.coords) - set(da.dims)
         if len(nondim_coords) > 0:

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -42,6 +42,10 @@ def _extract_dataarray_zattrs(da):
     zattrs = {}
     for k, v in da.attrs.items():
         zattrs[k] = encode_zarr_attr_value(v)
+
+    if da.coords:
+        zattrs['coordinates'] = encode_zarr_attr_value(' '.join(list(da.coords)))
+
     zattrs[DIMENSION_KEY] = list(da.dims)
 
     # We don't want `_FillValue` in `.zattrs`
@@ -104,10 +108,11 @@ def create_zmetadata(dataset):
     zmeta['metadata'][group_meta_key] = {'zarr_format': zarr_format}
     zmeta['metadata'][attrs_key] = _extract_dataset_zattrs(dataset)
 
-    for key, da in dataset.variables.items():
+    for key in dataset.variables.keys():
+        da = dataset[key]
         encoded_da = encode_zarr_variable(da, name=key)
         encoding = extract_zarr_variable_encoding(da)
-        zmeta['metadata'][f'{key}/{attrs_key}'] = _extract_dataarray_zattrs(encoded_da)
+        zmeta['metadata'][f'{key}/{attrs_key}'] = _extract_dataarray_zattrs(da)
         zmeta['metadata'][f'{key}/{array_meta_key}'] = _extract_zarray(
             encoded_da, encoding, encoded_da.dtype
         )

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -53,8 +53,11 @@ def _extract_dataarray_zattrs(da):
 
 def _extract_dataarray_coords(da, zattrs):
     '''helper function to extract coords from DataArray into a directionary'''
-    if da.coords:
-        zattrs['coordinates'] = encode_zarr_attr_value(' '.join(list(da.coords)))
+    if da.coords: 
+        # Coordinates are only encoded if there are non-dimension coordinates
+        nondim_coords = set(da.coords) - set(da.dims)
+        if len(nondim_coords) > 0:
+            zattrs['coordinates'] = encode_zarr_attr_value(' '.join(list(da.coords)))
     return zattrs
 
 

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -56,8 +56,10 @@ def _extract_dataarray_coords(da, zattrs):
     if da.coords:
         # Coordinates are only encoded if there are non-dimension coordinates
         nondim_coords = set(da.coords) - set(da.dims)
-        if len(nondim_coords) > 0:
-            zattrs['coordinates'] = encode_zarr_attr_value(' '.join(list(da.coords)))
+
+        if len(nondim_coords) > 0 and not da.name in nondim_coords:
+            coords = ' '.join(list(nondim_coords))
+            zattrs['coordinates'] = encode_zarr_attr_value(coords)
     return zattrs
 
 

--- a/xpublish/utils/zarr.py
+++ b/xpublish/utils/zarr.py
@@ -57,7 +57,7 @@ def _extract_dataarray_coords(da, zattrs):
         # Coordinates are only encoded if there are non-dimension coordinates
         nondim_coords = set(da.coords) - set(da.dims)
 
-        if len(nondim_coords) > 0 and not da.name in nondim_coords:
+        if len(nondim_coords) > 0 and da.name not in nondim_coords:
             coords = ' '.join(list(nondim_coords))
             zattrs['coordinates'] = encode_zarr_attr_value(coords)
     return zattrs


### PR DESCRIPTION
See #175 

Previously, the coordinates of each DataArray were not encoded, only the dims were. So we couldnt plot this how it is shown below. 


Tested with: 

```python
# We can access our API using fsspec's HTTPFileSystem
fs = HTTPFileSystem()

# The http mapper gives us a dict-like interface to the API
http_map = fs.get_mapper("http://0.0.0.0:8090/datasets/dbofs")

ds = xr.open_zarr(http_map, consolidated=True)
ds.temp.isel(ocean_time=0, s_rho=0).plot(x='lon_rho', y='lat_rho', cmap='jet')
```
![image](https://user-images.githubusercontent.com/1832671/229826770-66185b1d-478e-442a-8489-7564670cf391.png)

