### PR TITLE
Remove the empty region from Zarr encoding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pluggy
 pydantic>=2.5.0
 toolz
 uvicorn
-xarray>=2025.1.0
+xarray>=2025.7.0
 zarr>=3.0.7

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -51,7 +51,7 @@ def test_invalid_encoding_chunks_with_dask_raise():
     with pytest.raises(ValueError) as excinfo:
         _ = create_zmetadata(ds)
     excinfo.match(
-        r"Specified zarr chunks encoding\['chunks'\]=\(8, 5, 1\) for variable named None would overlap multiple dask chunks*"
+        r"Specified Zarr chunks encoding\['chunks'\]=\[8, 5, 1\] for variable named 'foo' would overlap multiple Dask chunks.*"
     )
 
 


### PR DESCRIPTION
As of Xarray > 2025.06.0 the region kwarg was removed from `xarray.backends.zarr.extract_zarr_variable_encoding` in https://github.com/pydata/xarray/pull/10336 and was causing our Zarr tests to fail. Most of the chunk related functionality was refactored into `xarray.backends.chunks` 

This bumps the xarray dependency  to `>=2025.7.0`.

Closes #316

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #318 
- <kbd>&nbsp;1&nbsp;</kbd> #317 👈 
<!-- GitButler Footer Boundary Bottom -->

