### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/source/user-guide/deployment/index.md
+++ b/docs/source/user-guide/deployment/index.md
@@ -4,4 +4,4 @@
 More coming soon.
 ```
 
-For now, take a look at some of the [server distributions](../ecosystem/index.md#server-distributions), or ask in [Github Discussions](https://github.com/xpublish-community/xpublish/discussions/categories/q-a?discussions_q=category%3AQ%26A+) or on our [Slack Channel](./ecosystem/index.md#slack).
+For now, take a look at some of the [server distributions](/ecosystem/index.md#server-distributions), or ask in [Github Discussions](https://github.com/xpublish-community/xpublish/discussions/categories/q-a?discussions_q=category%3AQ%26A+) or on our [Slack Channel](/ecosystem/index.md#slack).


### PR DESCRIPTION
These links currently do nothing when clicked, so I wanted to fix them!

Unfortunately, after following the contributing instructions, during local build, I encountered an error I didn't know what to do with:

```
reading sources... [  3%] api/endpoints
Exception occurred:
  File "/home/mfisher/micromamba/envs/xpublish-dev/lib/python3.14/site-packages/sphinxcontrib/openapi/directive.py", line 22, in _get_spec
    with open(abspath, 'rt', encoding=encoding) as stream:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/mfisher/Projects/earth-mover/xpublish/docs/source/api/openapi.json'
The full traceback has been saved in /tmp/sphinx-err-w_cz9qxw.log, if you want to report the issue to the developers.
```

So I'm hoping it's a local problem and that y'all have ReadTheDocs PR builds enabled and the build "just works" on the PR :)