### PR TITLE
Enable Pytest warnings filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,10 @@ asyncio_default_fixture_loop_scope = "function"
 log_cli = true
 log_level = "INFO"
 addopts = [ "--cov=xpublish", "--cov-report=xml", "--verbose", "-ra", "--strict-config", "--strict-markers" ]
-# filterwarnings = [ "error" ]
+filterwarnings = [
+  "error",
+  "ignore:numpy.ndarray size changed:RuntimeWarning",
+]
 strict = true
 testpaths = [ "tests" ]
 minversion = "9"

--- a/tests/test_plugin_management.py
+++ b/tests/test_plugin_management.py
@@ -29,7 +29,7 @@ def test_configure_plugins(airtemp_ds):
 
     info_response = client.get('/datasets/airtemp/meta/info')
     json_response = info_response.json()
-    assert json_response['dimensions'] == airtemp_ds.dims
+    assert json_response['dimensions'] == airtemp_ds.sizes
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
 
 
@@ -69,5 +69,5 @@ def test_overwrite_plugins(airtemp_ds):
     # /newinfo plugin should respond correctly
     info_response = client.get('/datasets/airtemp/newinfo/info')
     json_response = info_response.json()
-    assert json_response['dimensions'] == airtemp_ds.dims
+    assert json_response['dimensions'] == airtemp_ds.sizes
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -53,7 +53,7 @@ def dims_router():
 
     @router.get('/dims')
     def get_dims(dataset: xr.Dataset = Depends(get_dataset)):
-        return dataset.dims
+        return dataset.sizes
 
     return router
 
@@ -157,7 +157,7 @@ def test_custom_app_routers(airtemp_ds, dims_router, router_kws, path):
 
     response = client.get(path)
     assert response.status_code == 200
-    assert response.json() == airtemp_ds.dims
+    assert response.json() == airtemp_ds.sizes
 
     # test default routers not present
     response = client.get('/')
@@ -197,7 +197,7 @@ def test_custom_dataset_plugin(airtemp_ds, dataset_plugin):
 
     info_response = client.get('/datasets/airtemp/info')
     json_response = info_response.json()
-    assert json_response['dimensions'] == airtemp_ds.dims
+    assert json_response['dimensions'] == airtemp_ds.sizes
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
 
 
@@ -248,14 +248,14 @@ def test_info(airtemp_ds, airtemp_app_client):
     response = airtemp_app_client.get('/info')
     assert response.status_code == 200
     json_response = response.json()
-    assert json_response['dimensions'] == airtemp_ds.dims
+    assert json_response['dimensions'] == airtemp_ds.sizes
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
 
     # Second request, to make sure the cached data wasn't changed
     response = airtemp_app_client.get('/info')
     assert response.status_code == 200
     json_response = response.json()
-    assert json_response['dimensions'] == airtemp_ds.dims
+    assert json_response['dimensions'] == airtemp_ds.sizes
     assert list(json_response['variables'].keys()) == list(airtemp_ds.variables.keys())
 
 

--- a/xpublish/plugins/hooks.py
+++ b/xpublish/plugins/hooks.py
@@ -21,6 +21,15 @@ hookspec = pluggy.HookspecMarker('xpublish')
 # Decorator helper to mark functions as Xpublish hook implementations
 hookimpl = pluggy.HookimplMarker('xpublish')
 
+# Deprecated or otherwise inaccessible Pydantic fields that pluggy should ignore when inspecting plugins
+PYDANTIC_INACCESSIBLE_FIELDS = {
+    '__fields__',  # 2.0
+    '__fields_set__',  # 2.0
+    'model_computed_fields',  # 2.1
+    'model_fields',  # 2.1
+    '__signature__',  # Class only
+}
+
 
 class Plugin(BaseModel):
     """Xpublish plugins provide ways to extend the core of xpublish with new routers and other functionality.
@@ -55,9 +64,9 @@ class Plugin(BaseModel):
 
         https://github.com/pydantic/pydantic/pull/1466
         """
-        d = list(super().__dir__())
+        d = set(super().__dir__())
 
-        d.remove('__signature__')
+        d = d.difference(PYDANTIC_INACCESSIBLE_FIELDS)
 
         return d
 

--- a/xpublish/plugins/included/dataset_info.py
+++ b/xpublish/plugins/included/dataset_info.py
@@ -74,7 +74,7 @@ class DatasetInfoPlugin(Plugin):
 
             if info is None:
                 info = {
-                    'dimensions': dict(dataset.dims.items()),
+                    'dimensions': dict(dataset.sizes),
                     'variables': {
                         name: {
                             'type': var.dtype.name,


### PR DESCRIPTION
Cleaning up warnings from `dataset.dims` changes, and Pluggy trying to touch Pydantic’s things.

```py
FutureWarning('The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. To access a mapping from dimension names to lengths, please use `Dataset.sizes`.')
```

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #336 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #335 
<!-- GitButler Footer Boundary Bottom -->

