### PR TITLE
Switch to httpx2 for Starlette

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ entry-points."xpublish.plugin".plugin_info = "xpublish.plugins.included.plugin_i
 [dependency-groups]
 dev = [
   "fsspec",
-  "httpx",
+  "httpx2",
   "importlib-metadata",
   "netcdf4",
   "pooch",


### PR DESCRIPTION
Starlette has deprecated httpx for testing, so switching our dev requirements to use httpx2.