### PR TITLE
Allow same path with different HTTP methods in check_route_conflicts

### DIFF
--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -186,6 +186,43 @@ def test_custom_app_routers_conflict(airtemp_ds):
         Rest({'airtemp': airtemp_ds}, routers=[(router1, {'prefix': '/same'}), router2])
 
 
+def test_custom_app_routers_same_path_different_methods(airtemp_ds):
+    """Same path with disjoint HTTP methods (GET + POST) is not a conflict."""
+    router = APIRouter()
+
+    @router.get('/query')
+    def get_query():
+        return 'get'
+
+    @router.post('/query')
+    def post_query():
+        return 'post'
+
+    rest = SingleDatasetRest(airtemp_ds, routers=[router], plugins={})
+    client = TestClient(rest.app)
+
+    assert client.get('/query').json() == 'get'
+    assert client.post('/query').json() == 'post'
+
+
+def test_custom_app_routers_same_path_same_method_conflict(airtemp_ds):
+    """Two routes sharing both a path and a method is still a conflict."""
+    router1 = APIRouter()
+
+    @router1.get('/dup')
+    def first():
+        pass
+
+    router2 = APIRouter()
+
+    @router2.get('/dup')
+    def second():
+        pass
+
+    with pytest.raises(ValueError, match='Found multiple routes.*GET /dup'):
+        SingleDatasetRest(airtemp_ds, routers=[router1, router2], plugins={})
+
+
 def test_custom_dataset_plugin(airtemp_ds, dataset_plugin):
     rest = Rest({})
     rest.register_plugin(dataset_plugin)

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -96,29 +96,32 @@ def normalize_app_routers(
     return new_routers
 
 
-def check_route_conflicts(routers: list[tuple[APIRouter, dict]]) -> None:
+def check_route_conflicts(routers: list[tuple[APIRouter, dict[str, Any]]]) -> None:
     """Check for route conflicts in the given list of routers.
 
     Args:
         routers: A list of (APIRouter, {...}) tuples.
 
     Raises:
-        ValueError: If multiple routes are defined for the same path.
+        ValueError: If multiple routes are defined for the same path and HTTP
+            method. The same path with disjoint methods (e.g. a GET and a POST
+            query endpoint) is legitimate routing and is allowed.
     """
-    paths = []
-
-    for router, kws in routers:
-        prefix = kws.get('prefix', '')
-        paths += [prefix + r.path for r in router.routes]
-
     seen = set()
     duplicates = []
 
-    for p in paths:
-        if p in seen:
-            duplicates.append(p)
-        else:
-            seen.add(p)
+    for router, kws in routers:
+        prefix = kws.get('prefix', '')
+        for r in router.routes:
+            path = prefix + r.path  # type: ignore[attr-defined]
+            # Routes without methods (e.g. a Mount) collide on path alone.
+            methods = getattr(r, 'methods', None) or {None}
+            for method in methods:
+                key = (path, method)
+                if key in seen:
+                    duplicates.append(path if method is None else f'{method} {path}')
+                else:
+                    seen.add(key)
 
     if len(duplicates):
         raise ValueError(f'Found multiple routes defined for the following paths: {duplicates}')


### PR DESCRIPTION
`check_route_conflicts` deduped on path alone, so a plugin could not register a GET and a POST on the same path (e.g. an OGC EDR query endpoint where GET takes a required query parameter and POST reads a body). 

Key the conflict check on (path, method) instead; same path with disjoint methods is legitimate routing, while a genuine duplicate (same path and method) still raises.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #340 
- <kbd>&nbsp;1&nbsp;</kbd> #338 👈 
<!-- GitButler Footer Boundary Bottom -->

