### PR TITLE
Route conflicts and min deps

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -97,3 +97,26 @@ jobs:
       - name: Running Tests
         run: |
           python -m pytest --verbose
+
+  test-min-deps:
+    name: min-deps (3.11)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+        with:
+          enable-cache: true
+          python-version: "3.11"
+
+      - name: Install dev dependencies
+        run: uv sync --group dev
+
+      - name: Install package at minimum versions
+        run: uv pip install --resolution lowest-direct .
+
+      - name: Running Tests
+        run: uv run pytest --verbose

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,10 @@ with open('./.github/workflows/main.yaml') as f:
 
 python_versions = workflow['jobs']['test']['strategy']['matrix']['python-version']
 
+# Oldest supported interpreter, compared numerically so e.g. '3.9' sorts before
+# '3.14' (a plain string min() would compare lexicographically and get it wrong).
+min_python_version = min(python_versions, key=lambda v: tuple(int(p) for p in v.split('.')))
+
 with open('.readthedocs.yml') as f:
     rtd_config = yaml.safe_load(f)
 docs_python_version = rtd_config['build']['tools']['python']
@@ -33,11 +37,26 @@ def tests(session: nox.Session):
     )
 
 
-@nox.session
+@nox.session(python=min_python_version, name='min-deps', default=True)
+def min_deps(session: nox.Session):
+    """Run py.test against the minimum supported Python and dependency versions.
+
+    The test tooling (the ``dev`` group) is installed at its usual latest
+    versions; uv's ``lowest-direct`` resolution is applied only to the package
+    itself, pinning each runtime dependency to the floor of its version
+    specifier. This catches lower bounds that have drifted out of date, e.g.
+    using an API added after the minimum pinned version.
+    """
+    session.install('--group', 'dev')
+    session.install('--resolution', 'lowest-direct', '.')
+    session.run('pytest', '--verbose')
+
+
+@nox.session(default=False)
 def pre_commit(session: nox.Session):
     """Run pre-commit."""
-    session.install('pre-commit')
-    session.run('pre-commit', 'run')
+    session.install('prek')
+    session.run('prek', 'run')
 
 
 @nox.session(python=docs_python_version, default=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,14 @@ classifiers = [
 ]
 dynamic = [ "version" ]
 dependencies = [
-  "cachey",
+  "cachey>=0.2.1",
   "fastapi>=0.115",
-  "numpy",
-  "pluggy",
-  "pydantic>=2.5",
-  "toolz",
-  "uvicorn",
-  "xarray>=2025.7",
+  "numpy>=1.26",
+  "pluggy>=1",
+  "pydantic>=2.6",
+  "toolz>=0.12",
+  "uvicorn>=0.22",
+  "xarray>=2025.7.1",
 ]
 urls.documentation = "https://xpublish.readthedocs.io/"
 urls.repository = "https://github.com/xpublish-community/xpublish"
@@ -52,6 +52,10 @@ entry-points."xpublish.plugin".plugin_info = "xpublish.plugins.included.plugin_i
 [dependency-groups]
 dev = [
   "fsspec",
+  # Starlette's TestClient imports httpx2 on recent releases and plain httpx on
+  # older ones; keep both so the suite runs across the supported fastapi range
+  # (e.g. the min-deps session pins fastapi to its floor, pulling old starlette).
+  "httpx",
   "httpx2",
   "importlib-metadata",
   "netcdf4",

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -223,6 +223,31 @@ def test_custom_app_routers_same_path_same_method_conflict(airtemp_ds):
         SingleDatasetRest(airtemp_ds, routers=[router1, router2], plugins={})
 
 
+def test_custom_app_routers_with_included_subrouter(airtemp_ds):
+    """A router built with ``include_router`` must not break conflict checking.
+
+    On Starlette >= 1.0 / FastAPI >= 0.137, ``APIRouter.include_router`` keeps
+    the nested router as an ``_IncludedRouter`` entry in ``router.routes``
+    instead of flattening it into ``APIRoute`` objects. That entry has no
+    ``.path`` attribute, which previously made ``check_route_conflicts`` raise
+    ``AttributeError: '_IncludedRouter' object has no attribute 'path'``.
+    (Older Starlette flattened the routes, hiding the bug.)
+    """
+    child = APIRouter()
+
+    @child.get('/leaf')
+    def leaf():
+        return 'leaf'
+
+    parent = APIRouter()
+    parent.include_router(child, prefix='/sub')
+
+    rest = SingleDatasetRest(airtemp_ds, routers=[parent], plugins={})
+    client = TestClient(rest.app)
+
+    assert client.get('/sub/leaf').json() == 'leaf'
+
+
 def test_custom_dataset_plugin(airtemp_ds, dataset_plugin):
     rest = Rest({})
     rest.register_plugin(dataset_plugin)

--- a/xpublish/utils/api.py
+++ b/xpublish/utils/api.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from typing import Any
 
 import xarray as xr
@@ -96,6 +96,28 @@ def normalize_app_routers(
     return new_routers
 
 
+def _iter_route_paths(routes: list[Any], prefix: str) -> Iterator[tuple[str, Any]]:
+    """Yield ``(path, methods)`` for every leaf route under ``routes``.
+
+    Routes added via :meth:`fastapi.APIRouter.include_router` are not always
+    flattened into the parent's route list. On Starlette >= 1.0 the nested
+    router is kept as an ``_IncludedRouter`` entry that exposes neither
+    ``.path`` nor ``.methods``; its routes (and the prefix it was mounted at)
+    live on ``original_router`` and ``include_context``. Recurse into those so
+    conflict detection sees the same paths the running app will serve.
+    """
+    for r in routes:
+        if hasattr(r, 'path'):
+            yield prefix + r.path, getattr(r, 'methods', None)
+            continue
+
+        included = getattr(r, 'original_router', None)
+        context = getattr(r, 'include_context', None)
+        if included is not None and context is not None:
+            sub_prefix = prefix + getattr(context, 'prefix', '')
+            yield from _iter_route_paths(included.routes, sub_prefix)
+
+
 def check_route_conflicts(routers: list[tuple[APIRouter, dict[str, Any]]]) -> None:
     """Check for route conflicts in the given list of routers.
 
@@ -112,10 +134,9 @@ def check_route_conflicts(routers: list[tuple[APIRouter, dict[str, Any]]]) -> No
 
     for router, kws in routers:
         prefix = kws.get('prefix', '')
-        for r in router.routes:
-            path = prefix + r.path  # type: ignore[attr-defined]
+        for path, route_methods in _iter_route_paths(router.routes, prefix):
             # Routes without methods (e.g. a Mount) collide on path alone.
-            methods = getattr(r, 'methods', None) or {None}
+            methods = route_methods or {None}
             for method in methods:
                 key = (path, method)
                 if key in seen:


### PR DESCRIPTION
A recent Starlette/FastAPI release changed up how `check_route_conflicts()` behaves, especially in cases where the child routes don’t have prefixes. This caused an issue in downstream plugins.

To help catch those kinds of changes and to know when fixes may unintentionally raise our minimum (direct) dependencies, this also adds a minimum dependency test in both Actions and Nox. To do so the other install dependencies needed minimum versions which are all set to several years ago.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #340 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #338 
<!-- GitButler Footer Boundary Bottom -->

